### PR TITLE
Use the Guava Optional class rather than the one from Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,18 @@
             <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>17.0</version>
+			<scope>runtime</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.code.findbugs</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/org/apache/commons/rdf/Literal.java
+++ b/src/main/java/org/apache/commons/rdf/Literal.java
@@ -1,5 +1,7 @@
 package org.apache.commons.rdf;
 
+import com.google.common.base.Optional;
+
 public interface Literal extends RDFTerm {
 	String getLexicalForm() ;
 


### PR DESCRIPTION
Pull request for #5.

Quick swap of the JDK Option for Guava's, and hopefully correctly modifying the pom to reflect the dependency.
