### PR TITLE
Remove Graph.add(Collection), add Stream, remove boolean results from add/remove/clear

### DIFF
--- a/src/main/java/org/apache/commons/rdf/Graph.java
+++ b/src/main/java/org/apache/commons/rdf/Graph.java
@@ -35,11 +35,12 @@ public interface Graph {
      *
      * @param triple
      *            The triple to check.
+     * @return True if the Graph contains the given Triple.
      */
     boolean contains(Triple triple);
 
     /**
-     * Check if graph contains triple.
+     * Check if graph contains a pattern of triples.
      *
      * @param subject
      *            The triple subject (null is a wildcard)
@@ -47,6 +48,8 @@ public interface Graph {
      *            The triple predicate (null is a wildcard)
      * @param object
      *            The triple object (null is a wildcard)
+     * @return True if the Graph contains any Triples that match
+     *            the given pattern.
      */
     boolean contains(Resource subject, IRI predicate, RDFTerm object);
 


### PR DESCRIPTION
This pull request implements a few changes to the initial Graph interface:
- Remove Graph.add(Collection) per issue #11
- Change Iterator to Stream to take advantage of Java-8, per issue #10
- Remove boolean return values from add/remove/clear to ensure that the methods can be implemented with the least restrictions on the implementor. Requiring a boolean return value adds restrictions on the implementor with regard to synchronisation/parallelism. For example, if the Graph is implemented remotely, the library may need to actually perform the add to determine whether the triple was a new triple just to return a boolean value.
