### PR TITLE
Add RDFTerm.ntriplesString, IRI.getIRIString, and BlankNode.internalIdentifier, Fixes #14

### DIFF
--- a/src/main/java/org/apache/commons/rdf/BlankNode.java
+++ b/src/main/java/org/apache/commons/rdf/BlankNode.java
@@ -59,8 +59,8 @@ public interface BlankNode extends Resource {
      * >Skolemisation</a>, they may map instances of {@link BlankNode} objects
      * to {@link IRI} objects to reduce scoping issues.
      *
-     * @return A label for the {@link BlankNode}.
+     * @return An internal, locally scoped, identifier for the {@link BlankNode}.
      */
-    String getLabel();
+    String internalIdentifier();
 
 }

--- a/src/main/java/org/apache/commons/rdf/IRI.java
+++ b/src/main/java/org/apache/commons/rdf/IRI.java
@@ -7,4 +7,14 @@ package org.apache.commons.rdf;
  * and Abstract Syntax</a>, a W3C Recommendation published on 25 February 2014.<br>
  */
 public interface IRI extends Resource {
+
+	/**
+	 * Returns the IRI encoded as a native Unicode String.<br>
+	 * 
+	 * The returned string must not include URL-encoding to escape 
+	 * non-ASCII characters.
+	 * 
+	 * @return The IRI encoded as a native Unicode String.
+	 */
+    String getIRIString();
 }

--- a/src/main/java/org/apache/commons/rdf/RDFTerm.java
+++ b/src/main/java/org/apache/commons/rdf/RDFTerm.java
@@ -12,10 +12,12 @@ package org.apache.commons.rdf;
 public interface RDFTerm {
 
     /**
-     * Return the term representation (TBD)
+     * Return the term serialised as specified by the RDF-1.1 N-Triples Canonical form.
      *
-     * @return term representation
+     * @return The term serialised as RDF-1.1 N-Triples.
+     * @see <a href="http://www.w3.org/TR/n-triples/#canonical-ntriples">
+     *         RDF-1.1 N-Triples Canonical form</a>
      */
-    String toString();
+    String ntriplesString();
 
 }


### PR DESCRIPTION
Contains one way of fixing issue #14, but specifying a concrete representation, such as RDF-1.1 N-Triples Canonical, as the way of serialising any RDFTerm to a String, while adding a specific way of serialising IRI to a raw, un-quoted, string. It also modifies the method name that we already had on BlankNode to further indicate its scope.
