### PR TITLE
Add note about Stream and ConcurrentModificationException, fixes #13

### DIFF
--- a/src/main/java/org/apache/commons/rdf/Graph.java
+++ b/src/main/java/org/apache/commons/rdf/Graph.java
@@ -86,7 +86,13 @@ public interface Graph {
     long size();
 
     /**
-     * Get all triples contained by the graph.
+     * Get all triples contained by the graph.<br>
+     *
+     * The behaviour of the Stream is not specified if add, remove, or clear, 
+     * are called on the Stream before it terminates.<br>
+     *
+     * Implementations may throw ConcurrentModificationException from Stream 
+     * methods if they detect a conflict while the Stream is active.
      *
      * @return A {@link Stream} over all of the triples in the graph.
      */
@@ -94,6 +100,12 @@ public interface Graph {
 
     /**
      * Get all triples contained by the graph matched with the pattern.
+     *
+     * The behaviour of the Stream is not specified if add, remove, or clear, 
+     * are called on the Stream before it terminates.<br>
+     *
+     * Implementations may throw ConcurrentModificationException from Stream 
+     * methods if they detect a conflict while the Stream is active.
      *
      * @param subject
      *            The triple subject (null is a wildcard)


### PR DESCRIPTION
In response to discussion at #13, this enhances the contract to indicate that users need to be careful when using add, remove, or clear while a Stream is active.
