### PR TITLE
Rename Resource to BlankNodeOrIRI. Fixes #9

### DIFF
--- a/src/main/java/org/apache/commons/rdf/BlankNode.java
+++ b/src/main/java/org/apache/commons/rdf/BlankNode.java
@@ -25,7 +25,7 @@ package org.apache.commons.rdf;
  * @see <a href= "http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node">RDF-1.1
  * Blank Node</a>
  */
-public interface BlankNode extends Resource {
+public interface BlankNode extends BlankNodeOrIRI {
 
     /**
      * Return a <a href=

--- a/src/main/java/org/apache/commons/rdf/BlankNodeOrIRI.java
+++ b/src/main/java/org/apache/commons/rdf/BlankNodeOrIRI.java
@@ -1,0 +1,9 @@
+package org.apache.commons.rdf;
+
+/**
+ * This interface represents the {@link RDFTerm}s that may be used in the
+ * subject position of an RDF-1.1 {@link Triple}, including {@link BlankNode}
+ * and {@link IRI}.
+ */
+public interface BlankNodeOrIRI extends RDFTerm {
+}

--- a/src/main/java/org/apache/commons/rdf/Graph.java
+++ b/src/main/java/org/apache/commons/rdf/Graph.java
@@ -28,7 +28,7 @@ public interface Graph {
      * @param object
      *            The triple object
      */
-    void add(Resource subject, IRI predicate, RDFTerm object);
+    void add(BlankNodeOrIRI subject, IRI predicate, RDFTerm object);
 
     /**
      * Check if graph contains triple.
@@ -51,7 +51,7 @@ public interface Graph {
      * @return True if the Graph contains any Triples that match
      *            the given pattern.
      */
-    boolean contains(Resource subject, IRI predicate, RDFTerm object);
+    boolean contains(BlankNodeOrIRI subject, IRI predicate, RDFTerm object);
 
     /**
      * Remove a concrete triple from the graph.
@@ -71,7 +71,7 @@ public interface Graph {
      * @param object
      *            The triple object (null is a wildcard)
      */
-    void remove(Resource subject, IRI predicate, RDFTerm object);
+    void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object);
 
     /**
      * Clear the graph.
@@ -115,6 +115,6 @@ public interface Graph {
      *            The triple object (null is a wildcard)
      * @return A {@link Stream} over the matched triples.
      */
-    Stream<? extends Triple> getTriples(Resource subject, IRI predicate,
+    Stream<? extends Triple> getTriples(BlankNodeOrIRI subject, IRI predicate,
 			RDFTerm object);
 }

--- a/src/main/java/org/apache/commons/rdf/IRI.java
+++ b/src/main/java/org/apache/commons/rdf/IRI.java
@@ -6,7 +6,7 @@ package org.apache.commons.rdf;
  * "http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1 Concepts
  * and Abstract Syntax</a>, a W3C Recommendation published on 25 February 2014.<br>
  */
-public interface IRI extends Resource {
+public interface IRI extends BlankNodeOrIRI {
 
 	/**
 	 * Returns the IRI encoded as a native Unicode String.<br>

--- a/src/main/java/org/apache/commons/rdf/Quad.java
+++ b/src/main/java/org/apache/commons/rdf/Quad.java
@@ -19,7 +19,7 @@ public interface Quad {
      * @see <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-subject">RDF-1.1
      * Triple subject</a>
      */
-    Resource getSubject();
+    BlankNodeOrIRI getSubject();
 
     /**
      * The predicate {@link IRI} of this quad.
@@ -55,7 +55,7 @@ public interface Quad {
      * href="http://www.w3.org/TR/rdf11-concepts/#dfn-named-graph">RDF-1.1
      * Named Graph</a>
      */
-    Optional<Resource> getGraph();
+    Optional<BlankNodeOrIRI> getGraph();
 
     /**
      * A helper method used to convert to a {@link Triple}, removing any Graph

--- a/src/main/java/org/apache/commons/rdf/Resource.java
+++ b/src/main/java/org/apache/commons/rdf/Resource.java
@@ -1,4 +1,0 @@
-package org.apache.commons.rdf;
-
-public interface Resource extends RDFTerm {
-}

--- a/src/main/java/org/apache/commons/rdf/Triple.java
+++ b/src/main/java/org/apache/commons/rdf/Triple.java
@@ -20,7 +20,7 @@ public interface Triple {
      * @see <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-subject">RDF-1.1
      * Triple subject</a>
      */
-    Resource getSubject();
+    BlankNodeOrIRI getSubject();
 
     /**
      * The predicate {@link IRI} of this triple.


### PR DESCRIPTION
There has been extensive discussion about what name should be given to the class of objects that are allowed in the subject position of an RDF Triple, when using standard (non-generalised) RDF-1.1.

Resource, although used currently in some libraries to represent this term is semantically incorrect, as BlankNodes are not solely 'resources', they can represent Literals also.

Other potential names including RDFSubject, Node, NonLiteral, Identifier, and Reference have had objections, including both semantic and stylistic objections.

For these reasons, I am proposing switching back to BlankNodeOrIRI to enable discussion about other important issues to continue.

The full discussion can be found at:

https://github.com/wikier/commons-rdf/issues/9
