### PR TITLE
A bunch of unit tests and a Dummy implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ In order for this to work, your project will need to depend on the `tests`
 classifier, for example (for Maven):
 
     <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
         <groupId>com.github.commons-rdf</groupId>
         <artifactId>api</artifactId>
         <version>0.0.3-SNAPSHOT</version>

--- a/README.md
+++ b/README.md
@@ -55,13 +55,54 @@ To then depend on the Java 6 version in your Maven project, you need to use a sp
 
 Note that the Java 6 version depends on the [Guava libraries](https://code.google.com/p/guava-libraries/) for providing the missing features.
 
+## Example implementation
+
+For a simple example of how to minimally implement this API, see
+the [dummyimpl](src/test/java/com/github/commonsrdf/dummyimpl/)
+package that is part of the unit tests.
+
+Note that this is not to be considered as a 
+reference implementation, although it
+fully implements the commons-rdf API.
+
+
+## Testing
+
+The abstract classes
+[AbstractGraphTest](src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java)
+and 
+[AbstractRDFTermFactoryTest](src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java)
+can be realised as JUnit tests by implementations in order to verify that they
+pass the minimal requirements of this API.
+
+In order for this to work, your project will need to depend on the `tests`
+classifier, for example (for Maven):
+
+    <dependency>
+        <groupId>com.github.commons-rdf</groupId>
+        <artifactId>api</artifactId>
+        <version>0.0.3-SNAPSHOT</version>
+        <classifier>tests</classifier>
+        <scope>test</scope>
+    </dependency>
+
+The extensions of each Test class needs to provide a 
+[RDFTermFactory](src/test/java/com/github/commonsrdf/api/RDFTermFactory.java)
+that can create the corresponding implementations of a `Graph`, `IRI`, etc.
+
+For an example, see the
+[DummyGraphTest](src/test/java/com/github/commonsrdf/dummyimpl/DummyGraphTest.java)
+
+
 ## Contributors
 
 * Sergio Fernández ([Apache Marmotta](http://marmotta.apache.org))
 * Andy Seaborne ([Apache Jena](http://jena.apache.org))
 * Peter Ansell ([OpenRDF Sesame](http://openrdf.callimachus.net))
+* Stian Soiland-Reyes (([Apache Taverna](http://taverna.incubator.apache.org))
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute. In short - raise a Github pull request.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For an example, see
 * Sergio Fernández ([Apache Marmotta](http://marmotta.apache.org))
 * Andy Seaborne ([Apache Jena](http://jena.apache.org))
 * Peter Ansell ([OpenRDF Sesame](http://openrdf.callimachus.net))
-* Stian Soiland-Reyes (([Apache Taverna](http://taverna.incubator.apache.org))
+* Stian Soiland-Reyes ([Apache Taverna](http://taverna.incubator.apache.org))
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute. In short - raise a Github pull request.
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ The extensions of each Test class needs to provide a
 [RDFTermFactory](src/test/java/com/github/commonsrdf/api/RDFTermFactory.java)
 that can create the corresponding implementations of a `Graph`, `IRI`, etc.
 
-For an example, see the
-[DummyGraphTest](src/test/java/com/github/commonsrdf/dummyimpl/DummyGraphTest.java)
+For an example, see 
+[DummyGraphTest](src/test/java/com/github/commonsrdf/dummyimpl/DummyGraphTest.java).
 
 
 ## Contributors

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
                 <execution>
                   <goals>
                     <goal>jar</goal>
-                    <!-- <goal>test-jar</goal>-->
+                    <goal>test-jar</goal>
                   </goals>
                 </execution>
               </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,18 @@
                             <source>1.6</source>
                             <target>1.6</target>
                             <encoding>UTF-8</encoding>
+                            <testExcludes>
+                            	<exclude>**</exclude>
+                            </testExcludes>
                         </configuration>
+                    </plugin>
+                    <plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>2.17</version>	
+						<configuration>
+							<skip>true</skip>
+						</configuration>                    
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/com/github/commonsrdf/api/AbstractCommonsRDFTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractCommonsRDFTest.java
@@ -1,8 +1,6 @@
 package com.github.commonsrdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,11 +33,192 @@ public abstract class AbstractCommonsRDFTest {
 				"Second blank node has not got a unique internal identifier",
 				bnode.internalIdentifier(), bnode2.internalIdentifier());
 	}
-	
+
 	@Test
 	public void createBlankNodeIdentifier() throws Exception {
 		BlankNode bnode = factory.createBlankNode("example1");
-		assertEquals("example1", bnode.internalIdentifier());		
-		assertEquals("_:example1", bnode.ntriplesString());		
+		assertEquals("example1", bnode.internalIdentifier());
+		assertEquals("_:example1", bnode.ntriplesString());
 	}
+
+	@Test
+	public void createIRI() throws Exception {
+		IRI example = factory.createIRI("http://example.com/");
+		assertEquals("http://example.com/", example.getIRIString());
+		assertEquals("<http://example.com/>", example.ntriplesString());
+
+		IRI term = factory.createIRI("http://example.com/vocab#term");
+		assertEquals("http://example.com/vocab#term", term.getIRIString());
+		assertEquals("<http://example.com/vocab#term>", term.ntriplesString());
+
+		IRI relative = factory.createIRI("../relative");
+		assertEquals("../relative", relative.getIRIString());
+		assertEquals("<../relative>", relative.ntriplesString());
+
+		IRI relativeTerm = factory.createIRI("../relative#term");
+		assertEquals("../relative#term", relativeTerm.getIRIString());
+		assertEquals("<../relative#term>", relativeTerm.ntriplesString());
+
+		IRI emptyRelative = factory.createIRI(""); // <> equals the base URI
+		assertEquals("", emptyRelative.getIRIString());
+		assertEquals("<>", emptyRelative.ntriplesString());
+
+		
+		// and now for the international fun!
+
+		IRI latin1 = factory.createIRI("http://accént.example.com/première");
+		assertEquals("http://accént.example.com/première",
+				latin1.getIRIString());
+		assertEquals("<http://accént.example.com/première>",
+				latin1.ntriplesString());
+
+		IRI cyrillic = factory.createIRI("http://example.испытание/Кириллица");
+		assertEquals("http://example.испытание/Кириллица",
+				cyrillic.getIRIString());
+		assertEquals("<http://example.испытание/Кириллица>",
+				cyrillic.ntriplesString());
+
+		IRI deseret = factory.createIRI("http://𐐀.example.com/𐐀");
+		assertEquals("http://𐐀.example.com/𐐀", deseret.getIRIString());
+		assertEquals("<http://𐐀.example.com/𐐀>", deseret.ntriplesString());
+	}
+
+	@Test
+	public void createLiteral() throws Exception {
+		Literal example = factory.createLiteral("Example");
+		assertEquals("Example", example.getLexicalForm());
+		assertFalse(example.getLanguageTag().isPresent());
+		assertEquals("http://www.w3.org/2001/XMLSchema#string", example
+				.getDatatype().getIRIString());
+		// NOTE:
+		// http://lists.w3.org/Archives/Public/public-rdf-comments/2014Dec/0004.html
+		assertEquals("\"Example\"", example.ntriplesString());
+	}
+
+	@Test
+	public void createLiteralString() throws Exception {
+		Literal example = factory.createLiteral("Example",
+				factory.createIRI("http://www.w3.org/2001/XMLSchema#string"));
+		assertEquals("Example", example.getLexicalForm());
+		assertFalse(example.getLanguageTag().isPresent());
+		assertEquals("http://www.w3.org/2001/XMLSchema#string", example
+				.getDatatype().getIRIString());
+		// NOTE:
+		// http://lists.w3.org/Archives/Public/public-rdf-comments/2014Dec/0004.html
+		assertEquals("\"Example\"", example.ntriplesString());
+	}
+
+	@Test
+	public void createLiteralDateTime() throws Exception {
+		Literal dateTime = factory.createLiteral("2014-12-27T00:50:00T-0600",
+				factory.createIRI("http://www.w3.org/2001/XMLSchema#dateTime"));
+		assertEquals("2014-12-27T00:50:00T-0600", dateTime.getLexicalForm());
+		assertFalse(dateTime.getLanguageTag().isPresent());
+		assertEquals("http://www.w3.org/2001/XMLSchema#dateTime", dateTime
+				.getDatatype().getIRIString());
+		assertEquals(
+				"\"2014-12-27T00:50:00T-0600\"^^<http://www.w3.org/2001/XMLSchema#dateTime>",
+				dateTime.ntriplesString());
+	}
+
+	@Test
+	public void createLiteralLang() throws Exception {
+		Literal example = factory.createLiteral("Example", "en");
+		assertEquals("Example", example.getLexicalForm());
+		assertEquals("en", example.getLanguageTag().get());
+		assertEquals("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
+				example.getDatatype().getIRIString());
+		assertEquals("\"Example\"@en", example.ntriplesString());
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void invalidLiteralLang() throws Exception {
+		factory.createLiteral("Example", "");		
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void invalidBlankNode() throws Exception {
+		factory.createBlankNode("with:colon");
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void invalidIRI() throws Exception {
+		factory.createIRI("<no_brackets>");
+	}
+	
+	@Test
+	public void createGraph() {
+		Graph graph = factory.createGraph();
+		assertEquals("Graph was not empty", 0, graph.size());
+		graph.add(factory.createBlankNode(),  
+				factory.createIRI("http://example.com/"),
+				factory.createBlankNode());
+		
+		Graph graph2 = factory.createGraph();
+		assertNotSame(graph, graph2);
+		assertEquals("Graph was empty after adding", 1, graph.size());
+		assertEquals("New graph was not empty", 0, graph2.size());
+	}
+	
+	@Test
+	public void createTripleBnodeTriple() {
+		BlankNode subject = factory.createBlankNode();
+		IRI predicate = factory.createIRI("http://example.com/pred");
+		Literal object = factory.createLiteral("Example", "en");
+		Triple triple = factory.createTriple(subject, predicate, object);
+		
+		// NOTE: We do not require object equivalence after insertion,
+		// but the ntriples should match
+		assertEquals(subject.ntriplesString(), 
+				triple.getSubject().ntriplesString());
+		assertEquals(predicate.ntriplesString(), 
+				triple.getPredicate().ntriplesString());
+		assertEquals(object.ntriplesString(), 
+				triple.getObject().ntriplesString());		
+	}
+	
+
+	@Test
+	public void createTripleBnodeBnode() {
+		BlankNode subject = factory.createBlankNode("b1");
+		IRI predicate = factory.createIRI("http://example.com/pred");
+		BlankNode object = factory.createBlankNode("b2");
+		Triple triple = factory.createTriple(subject, predicate, object);
+		
+		// NOTE: We do not require object equivalence after insertion,
+		// but the ntriples should match
+		assertEquals(subject.ntriplesString(), 
+				triple.getSubject().ntriplesString());
+		assertEquals(predicate.ntriplesString(), 
+				triple.getPredicate().ntriplesString());
+		assertEquals(object.ntriplesString(), 
+				triple.getObject().ntriplesString());		
+	
+	}
+
+	@Test
+	public void createTripleBnodeIRI() {
+		BlankNode subject = factory.createBlankNode("b1");
+		IRI predicate = factory.createIRI("http://example.com/pred");
+		IRI object = factory.createIRI("http://example.com/obj");
+		Triple triple = factory.createTriple(subject, predicate, object);
+		
+		// NOTE: We do not require object equivalence after insertion,
+		// but the ntriples should match
+		assertEquals(subject.ntriplesString(), 
+				triple.getSubject().ntriplesString());
+		assertEquals(predicate.ntriplesString(), 
+				triple.getPredicate().ntriplesString());
+		assertEquals(object.ntriplesString(), 
+				triple.getObject().ntriplesString());		
+	}
+
+	@Test(expected=Exception.class)
+	public void invalidTriplePredicate() {
+		BlankNode subject = factory.createBlankNode("b1");
+		BlankNode predicate = factory.createBlankNode("b2");
+		BlankNode object = factory.createBlankNode("b3");
+		factory.createTriple(subject, (IRI) predicate, object);
+	}
+	
 }

--- a/src/test/java/com/github/commonsrdf/api/AbstractCommonsRDFTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractCommonsRDFTest.java
@@ -13,13 +13,6 @@ public abstract class AbstractCommonsRDFTest {
 
 	private RDFTermFactory factory;
 
-	@Before
-	public void getFactory() {
-		factory = createFactory();
-	}
-
-	public abstract RDFTermFactory createFactory();
-
 	@Test
 	public void createBlankNode() throws Exception {
 		BlankNode bnode = factory.createBlankNode();
@@ -43,6 +36,22 @@ public abstract class AbstractCommonsRDFTest {
 		BlankNode bnode = factory.createBlankNode("example1");
 		assertEquals("example1", bnode.internalIdentifier());
 		assertEquals("_:example1", bnode.ntriplesString());
+	}
+
+	public abstract RDFTermFactory createFactory();
+
+	@Test
+	public void createGraph() {
+		Graph graph = factory.createGraph();
+		assertEquals("Graph was not empty", 0, graph.size());
+		graph.add(factory.createBlankNode(),
+				factory.createIRI("http://example.com/"),
+				factory.createBlankNode());
+
+		Graph graph2 = factory.createGraph();
+		assertNotSame(graph, graph2);
+		assertEquals("Graph was empty after adding", 1, graph.size());
+		assertEquals("New graph was not empty", 0, graph2.size());
 	}
 
 	@Test
@@ -98,18 +107,6 @@ public abstract class AbstractCommonsRDFTest {
 	}
 
 	@Test
-	public void createLiteralString() throws Exception {
-		Literal example = factory.createLiteral("Example",
-				factory.createIRI("http://www.w3.org/2001/XMLSchema#string"));
-		assertEquals("Example", example.getLexicalForm());
-		assertFalse(example.getLanguageTag().isPresent());
-		assertEquals("http://www.w3.org/2001/XMLSchema#string", example
-				.getDatatype().getIRIString());
-		// http://lists.w3.org/Archives/Public/public-rdf-comments/2014Dec/0004.html
-		assertEquals("\"Example\"", example.ntriplesString());
-	}
-
-	@Test
 	public void createLiteralDateTime() throws Exception {
 		Literal dateTime = factory.createLiteral("2014-12-27T00:50:00T-0600",
 				factory.createIRI("http://www.w3.org/2001/XMLSchema#dateTime"));
@@ -132,50 +129,16 @@ public abstract class AbstractCommonsRDFTest {
 		assertEquals("\"Example\"@en", example.ntriplesString());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void invalidLiteralLang() throws Exception {
-		factory.createLiteral("Example", "");
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void invalidBlankNode() throws Exception {
-		factory.createBlankNode("with:colon");
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void invalidIRI() throws Exception {
-		factory.createIRI("<no_brackets>");
-	}
-
 	@Test
-	public void createGraph() {
-		Graph graph = factory.createGraph();
-		assertEquals("Graph was not empty", 0, graph.size());
-		graph.add(factory.createBlankNode(),
-				factory.createIRI("http://example.com/"),
-				factory.createBlankNode());
-
-		Graph graph2 = factory.createGraph();
-		assertNotSame(graph, graph2);
-		assertEquals("Graph was empty after adding", 1, graph.size());
-		assertEquals("New graph was not empty", 0, graph2.size());
-	}
-
-	@Test
-	public void createTripleBnodeTriple() {
-		BlankNode subject = factory.createBlankNode();
-		IRI predicate = factory.createIRI("http://example.com/pred");
-		Literal object = factory.createLiteral("Example", "en");
-		Triple triple = factory.createTriple(subject, predicate, object);
-
-		// NOTE: We do not require object equivalence after insertion,
-		// but the ntriples should match
-		assertEquals(subject.ntriplesString(), triple.getSubject()
-				.ntriplesString());
-		assertEquals(predicate.ntriplesString(), triple.getPredicate()
-				.ntriplesString());
-		assertEquals(object.ntriplesString(), triple.getObject()
-				.ntriplesString());
+	public void createLiteralString() throws Exception {
+		Literal example = factory.createLiteral("Example",
+				factory.createIRI("http://www.w3.org/2001/XMLSchema#string"));
+		assertEquals("Example", example.getLexicalForm());
+		assertFalse(example.getLanguageTag().isPresent());
+		assertEquals("http://www.w3.org/2001/XMLSchema#string", example
+				.getDatatype().getIRIString());
+		// http://lists.w3.org/Archives/Public/public-rdf-comments/2014Dec/0004.html
+		assertEquals("\"Example\"", example.ntriplesString());
 	}
 
 	@Test
@@ -211,6 +174,43 @@ public abstract class AbstractCommonsRDFTest {
 				.ntriplesString());
 		assertEquals(object.ntriplesString(), triple.getObject()
 				.ntriplesString());
+	}
+
+	@Test
+	public void createTripleBnodeTriple() {
+		BlankNode subject = factory.createBlankNode();
+		IRI predicate = factory.createIRI("http://example.com/pred");
+		Literal object = factory.createLiteral("Example", "en");
+		Triple triple = factory.createTriple(subject, predicate, object);
+
+		// NOTE: We do not require object equivalence after insertion,
+		// but the ntriples should match
+		assertEquals(subject.ntriplesString(), triple.getSubject()
+				.ntriplesString());
+		assertEquals(predicate.ntriplesString(), triple.getPredicate()
+				.ntriplesString());
+		assertEquals(object.ntriplesString(), triple.getObject()
+				.ntriplesString());
+	}
+
+	@Before
+	public void getFactory() {
+		factory = createFactory();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void invalidBlankNode() throws Exception {
+		factory.createBlankNode("with:colon");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void invalidIRI() throws Exception {
+		factory.createIRI("<no_brackets>");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void invalidLiteralLang() throws Exception {
+		factory.createLiteral("Example", "");
 	}
 
 	@Test(expected = Exception.class)

--- a/src/test/java/com/github/commonsrdf/api/AbstractCommonsRDFTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractCommonsRDFTest.java
@@ -1,6 +1,10 @@
 package com.github.commonsrdf.api;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -63,7 +67,6 @@ public abstract class AbstractCommonsRDFTest {
 		assertEquals("", emptyRelative.getIRIString());
 		assertEquals("<>", emptyRelative.ntriplesString());
 
-		
 		// and now for the international fun!
 
 		IRI latin1 = factory.createIRI("http://accént.example.com/première");
@@ -90,7 +93,6 @@ public abstract class AbstractCommonsRDFTest {
 		assertFalse(example.getLanguageTag().isPresent());
 		assertEquals("http://www.w3.org/2001/XMLSchema#string", example
 				.getDatatype().getIRIString());
-		// NOTE:
 		// http://lists.w3.org/Archives/Public/public-rdf-comments/2014Dec/0004.html
 		assertEquals("\"Example\"", example.ntriplesString());
 	}
@@ -103,7 +105,6 @@ public abstract class AbstractCommonsRDFTest {
 		assertFalse(example.getLanguageTag().isPresent());
 		assertEquals("http://www.w3.org/2001/XMLSchema#string", example
 				.getDatatype().getIRIString());
-		// NOTE:
 		// http://lists.w3.org/Archives/Public/public-rdf-comments/2014Dec/0004.html
 		assertEquals("\"Example\"", example.ntriplesString());
 	}
@@ -131,52 +132,51 @@ public abstract class AbstractCommonsRDFTest {
 		assertEquals("\"Example\"@en", example.ntriplesString());
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void invalidLiteralLang() throws Exception {
-		factory.createLiteral("Example", "");		
+		factory.createLiteral("Example", "");
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
+
+	@Test(expected = IllegalArgumentException.class)
 	public void invalidBlankNode() throws Exception {
 		factory.createBlankNode("with:colon");
 	}
-	
-	@Test(expected=IllegalArgumentException.class)
+
+	@Test(expected = IllegalArgumentException.class)
 	public void invalidIRI() throws Exception {
 		factory.createIRI("<no_brackets>");
 	}
-	
+
 	@Test
 	public void createGraph() {
 		Graph graph = factory.createGraph();
 		assertEquals("Graph was not empty", 0, graph.size());
-		graph.add(factory.createBlankNode(),  
+		graph.add(factory.createBlankNode(),
 				factory.createIRI("http://example.com/"),
 				factory.createBlankNode());
-		
+
 		Graph graph2 = factory.createGraph();
 		assertNotSame(graph, graph2);
 		assertEquals("Graph was empty after adding", 1, graph.size());
 		assertEquals("New graph was not empty", 0, graph2.size());
 	}
-	
+
 	@Test
 	public void createTripleBnodeTriple() {
 		BlankNode subject = factory.createBlankNode();
 		IRI predicate = factory.createIRI("http://example.com/pred");
 		Literal object = factory.createLiteral("Example", "en");
 		Triple triple = factory.createTriple(subject, predicate, object);
-		
+
 		// NOTE: We do not require object equivalence after insertion,
 		// but the ntriples should match
-		assertEquals(subject.ntriplesString(), 
-				triple.getSubject().ntriplesString());
-		assertEquals(predicate.ntriplesString(), 
-				triple.getPredicate().ntriplesString());
-		assertEquals(object.ntriplesString(), 
-				triple.getObject().ntriplesString());		
+		assertEquals(subject.ntriplesString(), triple.getSubject()
+				.ntriplesString());
+		assertEquals(predicate.ntriplesString(), triple.getPredicate()
+				.ntriplesString());
+		assertEquals(object.ntriplesString(), triple.getObject()
+				.ntriplesString());
 	}
-	
 
 	@Test
 	public void createTripleBnodeBnode() {
@@ -184,16 +184,16 @@ public abstract class AbstractCommonsRDFTest {
 		IRI predicate = factory.createIRI("http://example.com/pred");
 		BlankNode object = factory.createBlankNode("b2");
 		Triple triple = factory.createTriple(subject, predicate, object);
-		
+
 		// NOTE: We do not require object equivalence after insertion,
 		// but the ntriples should match
-		assertEquals(subject.ntriplesString(), 
-				triple.getSubject().ntriplesString());
-		assertEquals(predicate.ntriplesString(), 
-				triple.getPredicate().ntriplesString());
-		assertEquals(object.ntriplesString(), 
-				triple.getObject().ntriplesString());		
-	
+		assertEquals(subject.ntriplesString(), triple.getSubject()
+				.ntriplesString());
+		assertEquals(predicate.ntriplesString(), triple.getPredicate()
+				.ntriplesString());
+		assertEquals(object.ntriplesString(), triple.getObject()
+				.ntriplesString());
+
 	}
 
 	@Test
@@ -202,23 +202,23 @@ public abstract class AbstractCommonsRDFTest {
 		IRI predicate = factory.createIRI("http://example.com/pred");
 		IRI object = factory.createIRI("http://example.com/obj");
 		Triple triple = factory.createTriple(subject, predicate, object);
-		
+
 		// NOTE: We do not require object equivalence after insertion,
 		// but the ntriples should match
-		assertEquals(subject.ntriplesString(), 
-				triple.getSubject().ntriplesString());
-		assertEquals(predicate.ntriplesString(), 
-				triple.getPredicate().ntriplesString());
-		assertEquals(object.ntriplesString(), 
-				triple.getObject().ntriplesString());		
+		assertEquals(subject.ntriplesString(), triple.getSubject()
+				.ntriplesString());
+		assertEquals(predicate.ntriplesString(), triple.getPredicate()
+				.ntriplesString());
+		assertEquals(object.ntriplesString(), triple.getObject()
+				.ntriplesString());
 	}
 
-	@Test(expected=Exception.class)
+	@Test(expected = Exception.class)
 	public void invalidTriplePredicate() {
 		BlankNode subject = factory.createBlankNode("b1");
 		BlankNode predicate = factory.createBlankNode("b2");
 		BlankNode object = factory.createBlankNode("b3");
 		factory.createTriple(subject, (IRI) predicate, object);
 	}
-	
+
 }

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -3,6 +3,8 @@ package com.github.commonsrdf.api;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.*;
+
 public abstract class AbstractGraphTest {
 
 	private RDFTermFactory factory;
@@ -27,6 +29,8 @@ public abstract class AbstractGraphTest {
 	@Before
 	public void createGraph() {
 		graph = factory.createGraph();
+		assertEquals(0, graph.size());
+		
 		alice = factory.createIRI("http://example.com/alice");
 		bob = factory.createIRI("http://example.com/bob");
 		name = factory.createIRI("http://xmlns.com/foaf/0.1/name");
@@ -34,23 +38,61 @@ public abstract class AbstractGraphTest {
 		member = factory.createIRI("http://xmlns.com/foaf/0.1/member");
 		org1 = factory.createBlankNode("org1");
 		org2 = factory.createBlankNode("org2");
-		aliceLit = factory.createLiteral("Alice");
-		bobLit = factory.createLiteral("Bob", "en-US");
 		
-		graph.add(alice, name, aliceLit);
+		graph.add(alice, name, factory.createLiteral("Alice"));
 		graph.add(alice, knows, bob);
 		graph.add(alice, member, org1);
-		graph.add(bob, name, bobLit);
-		graph.add(bob, knows, alice);
-		graph.add(bob, member, org1);
-		graph.add(bob, member, org2);
+		// and for Bob we'll try as Triples
+		graph.add(factory.createTriple(bob, name, factory.createLiteral("Bob", "en-US"))); 
+		graph.add(factory.createTriple(bob, member, org1));
+		graph.add(factory.createTriple(bob, member, org2));
+		
+		graph.add(org1, name, factory.createLiteral("The Secret Club"));
+		graph.add(org1, name, factory.createLiteral("A company"));
+	}
+	
+	
+	@Test
+	public void graphToString() {
+		
 		System.out.println(graph);
+		assertTrue(graph.toString().startsWith(
+				"<http://example.com/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" ."));
+		assertTrue(graph.toString().endsWith(
+				"_:org1 <http://xmlns.com/foaf/0.1/name> \"A company\" ."));
+		
 	}
 	
 	@Test
-	public void testName() throws Exception {
-		
-		
+	public void size() throws Exception {
+		assertEquals(8, graph.size());
+	}
+	
+	@Test
+	public void contains() throws Exception {
+		assertTrue(graph.contains(alice, knows, bob));
+		assertFalse(graph.contains(bob, knows, alice)); // or so he claims..
+	}
+	
+	@Test
+	public void remove() throws Exception {
+		graph.remove(alice, knows, bob);
+		assertEquals(7, graph.size());	
+		graph.remove(alice, knows, bob);
+		assertEquals(7, graph.size());
+		graph.add(alice, knows, bob);
+		graph.add(alice, knows, bob);
+		graph.add(alice, knows, bob);
+		// Undetermined size at this point
+		//assertEquals(8, graph.size());
+		// but at least after remove they should all be gone
+		graph.remove(alice, knows, bob);
+		assertEquals(7, graph.size());
+	}
+	
+	@Test
+	public void something() throws Exception {
+	}		
 	}
 	
 	

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -67,25 +67,25 @@ public abstract class AbstractGraphTest {
 		name = factory.createIRI("http://xmlns.com/foaf/0.1/name");
 		knows = factory.createIRI("http://xmlns.com/foaf/0.1/knows");
 		member = factory.createIRI("http://xmlns.com/foaf/0.1/member");
-		try { 
+		try {
 			org1 = factory.createBlankNode("org1");
 			org2 = factory.createBlankNode("org2");
 		} catch (UnsupportedOperationException ex) {
 			// leave as null
 		}
-		
-		try { 
+
+		try {
 			secretClubName = factory.createLiteral("The Secret Club");
 			companyName = factory.createLiteral("A company");
 			aliceName = factory.createLiteral("Alice");
 			bobName = factory.createLiteral("Bob", "en-US");
-		} catch (UnsupportedOperationException ex) { 
+		} catch (UnsupportedOperationException ex) {
 			// leave as null
-		} 
-		
+		}
+
 		if (aliceName != null) {
 			graph.add(alice, name, aliceName);
-		} 
+		}
 		graph.add(alice, knows, bob);
 
 		if (org1 != null) {
@@ -93,9 +93,9 @@ public abstract class AbstractGraphTest {
 		}
 
 		if (bobName != null) {
-			try { 
+			try {
 				bobNameTriple = factory.createTriple(bob, name, bobName);
-			} catch (UnsupportedOperationException ex) { 
+			} catch (UnsupportedOperationException ex) {
 				// leave as null
 			}
 			if (bobNameTriple != null) {
@@ -104,7 +104,7 @@ public abstract class AbstractGraphTest {
 		}
 		if (org1 != null) {
 			graph.add(factory.createTriple(bob, member, org1));
-			graph.add(factory.createTriple(bob, member, org2));	
+			graph.add(factory.createTriple(bob, member, org2));
 			if (secretClubName != null) {
 				graph.add(org1, name, secretClubName);
 				graph.add(org1, name, companyName);
@@ -128,8 +128,9 @@ public abstract class AbstractGraphTest {
 	@Test
 	public void size() throws Exception {
 		assertTrue(graph.size() > 0);
-		Assume.assumeNotNull(org1, org2, aliceName, bobName, secretClubName, companyName, bobNameTriple); 
-		// Can only reliably predict size if we could create all triples 
+		Assume.assumeNotNull(org1, org2, aliceName, bobName, secretClubName,
+				companyName, bobNameTriple);
+		// Can only reliably predict size if we could create all triples
 		assertEquals(8, graph.size());
 	}
 
@@ -139,23 +140,23 @@ public abstract class AbstractGraphTest {
 
 		assertTrue(graph.contains(alice, knows, bob));
 
-		Optional<? extends Triple> first = graph.getTriples().skip(4).findFirst();
+		Optional<? extends Triple> first = graph.getTriples().skip(4)
+				.findFirst();
 		Assume.assumeTrue(first.isPresent());
 		Triple existingTriple = first.get();
 		assertTrue(graph.contains(existingTriple));
-		
+
 		Triple nonExistingTriple = factory.createTriple(bob, knows, alice);
 		assertFalse(graph.contains(nonExistingTriple));
-		
-		
+
 		Triple triple = null;
-		try  {
+		try {
 			triple = factory.createTriple(alice, knows, bob);
 		} catch (UnsupportedOperationException ex) {
 		}
 		if (triple != null) {
 			// FIXME: Should not this always be true?
-			//	assertTrue(graph.contains(triple));
+			// assertTrue(graph.contains(triple));
 		}
 	}
 
@@ -164,25 +165,25 @@ public abstract class AbstractGraphTest {
 		long fullSize = graph.size();
 		graph.remove(alice, knows, bob);
 		long shrunkSize = graph.size();
-		assertEquals(1,  fullSize - shrunkSize);
+		assertEquals(1, fullSize - shrunkSize);
 
 		graph.remove(alice, knows, bob);
 		assertEquals(shrunkSize, graph.size()); // unchanged
-		
+
 		graph.add(alice, knows, bob);
 		graph.add(alice, knows, bob);
 		graph.add(alice, knows, bob);
 		// Undetermined size at this point -- but at least it
 		// should be bigger
 		assertTrue(graph.size() > shrunkSize);
-		
+
 		// and after a single remove they should all be gone
 		graph.remove(alice, knows, bob);
 		assertEquals(shrunkSize, graph.size());
 
 		Optional<? extends Triple> anyTriple = graph.getTriples().findAny();
 		Assume.assumeTrue(anyTriple.isPresent());
-		
+
 		Triple otherTriple = anyTriple.get();
 		graph.remove(otherTriple);
 		assertEquals(shrunkSize - 1, graph.size());
@@ -191,7 +192,7 @@ public abstract class AbstractGraphTest {
 		graph.add(otherTriple);
 		assertEquals(shrunkSize, graph.size());
 	}
- 
+
 	@Test
 	public void clear() throws Exception {
 		graph.clear();
@@ -203,23 +204,24 @@ public abstract class AbstractGraphTest {
 
 	@Test
 	public void getTriples() throws Exception {
-		
+
 		long tripleCount = graph.getTriples().count();
 		assertTrue(tripleCount > 0);
 		assertTrue(graph.getTriples().allMatch(t -> graph.contains(t)));
 		// Check exact count
-		Assume.assumeNotNull(org1, org2, aliceName, bobName, secretClubName, companyName, bobNameTriple);
+		Assume.assumeNotNull(org1, org2, aliceName, bobName, secretClubName,
+				companyName, bobNameTriple);
 		assertEquals(8, tripleCount);
 	}
 
 	@Test
 	public void getTriplesQuery() throws Exception {
-		
+
 		long aliceCount = graph.getTriples(alice, null, null).count();
 		assertTrue(aliceCount > 0);
 		Assume.assumeNotNull(aliceName);
 		assertEquals(3, aliceCount);
-		
+
 		Assume.assumeNotNull(org1, org2, bobName, companyName, secretClubName);
 		assertEquals(4, graph.getTriples(null, name, null).count());
 		Assume.assumeNotNull(org1);

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -1,0 +1,57 @@
+package com.github.commonsrdf.api;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class AbstractGraphTest {
+
+	private RDFTermFactory factory;
+	private Graph graph;
+	private IRI alice;
+	private IRI bob;
+	private IRI name;
+	private IRI knows;
+	private IRI member;
+	private BlankNode org1;
+	private BlankNode org2;
+	private Literal aliceLit;
+	private Literal bobLit;
+
+	@Before
+	public void getFactory() {
+		factory = createFactory();
+	}
+
+	public abstract RDFTermFactory createFactory();
+
+	@Before
+	public void createGraph() {
+		graph = factory.createGraph();
+		alice = factory.createIRI("http://example.com/alice");
+		bob = factory.createIRI("http://example.com/bob");
+		name = factory.createIRI("http://xmlns.com/foaf/0.1/name");
+		knows = factory.createIRI("http://xmlns.com/foaf/0.1/knows");
+		member = factory.createIRI("http://xmlns.com/foaf/0.1/member");
+		org1 = factory.createBlankNode("org1");
+		org2 = factory.createBlankNode("org2");
+		aliceLit = factory.createLiteral("Alice");
+		bobLit = factory.createLiteral("Bob", "en-US");
+		
+		graph.add(alice, name, aliceLit);
+		graph.add(alice, knows, bob);
+		graph.add(alice, member, org1);
+		graph.add(bob, name, bobLit);
+		graph.add(bob, knows, alice);
+		graph.add(bob, member, org1);
+		graph.add(bob, member, org2);
+		System.out.println(graph);
+	}
+	
+	@Test
+	public void testName() throws Exception {
+		
+		
+	}
+	
+	
+}

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -1,9 +1,14 @@
 package com.github.commonsrdf.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 public abstract class AbstractGraphTest {
 
@@ -16,21 +21,15 @@ public abstract class AbstractGraphTest {
 	private IRI member;
 	private BlankNode org1;
 	private BlankNode org2;
-	private Literal aliceLit;
-	private Literal bobLit;
-
-	@Before
-	public void getFactory() {
-		factory = createFactory();
-	}
 
 	public abstract RDFTermFactory createFactory();
 
 	@Before
-	public void createGraph() {
+	public void createGraphAndAdd() {
+		factory = createFactory();
 		graph = factory.createGraph();
 		assertEquals(0, graph.size());
-		
+
 		alice = factory.createIRI("http://example.com/alice");
 		bob = factory.createIRI("http://example.com/bob");
 		name = factory.createIRI("http://xmlns.com/foaf/0.1/name");
@@ -38,62 +37,149 @@ public abstract class AbstractGraphTest {
 		member = factory.createIRI("http://xmlns.com/foaf/0.1/member");
 		org1 = factory.createBlankNode("org1");
 		org2 = factory.createBlankNode("org2");
-		
+
 		graph.add(alice, name, factory.createLiteral("Alice"));
 		graph.add(alice, knows, bob);
 		graph.add(alice, member, org1);
 		// and for Bob we'll try as Triples
-		graph.add(factory.createTriple(bob, name, factory.createLiteral("Bob", "en-US"))); 
+		graph.add(factory.createTriple(bob, name,
+				factory.createLiteral("Bob", "en-US")));
 		graph.add(factory.createTriple(bob, member, org1));
 		graph.add(factory.createTriple(bob, member, org2));
-		
+
 		graph.add(org1, name, factory.createLiteral("The Secret Club"));
 		graph.add(org1, name, factory.createLiteral("A company"));
 	}
-	
-	
+
 	@Test
 	public void graphToString() {
-		
+
 		System.out.println(graph);
-		assertTrue(graph.toString().startsWith(
-				"<http://example.com/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" ."));
+		assertTrue(graph
+				.toString()
+				.startsWith(
+						"<http://example.com/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" ."));
 		assertTrue(graph.toString().endsWith(
 				"_:org1 <http://xmlns.com/foaf/0.1/name> \"A company\" ."));
-		
+
 	}
-	
+
 	@Test
 	public void size() throws Exception {
 		assertEquals(8, graph.size());
 	}
-	
+
 	@Test
 	public void contains() throws Exception {
-		assertTrue(graph.contains(alice, knows, bob));
 		assertFalse(graph.contains(bob, knows, alice)); // or so he claims..
+
+		assertTrue(graph.contains(alice, knows, bob));
+
+		Triple triple = factory.createTriple(alice, knows, bob);
+		// FIXME: Should not this be true?
+		// assertTrue(graph.contains(triple));
+
+		Triple existingTriple = graph.getTriples().skip(4).findFirst().get();
+		assertTrue(graph.contains(existingTriple));
+
+		Triple nonExistingTriple = factory.createTriple(bob, knows, alice);
+		assertFalse(graph.contains(nonExistingTriple));
 	}
-	
+
 	@Test
 	public void remove() throws Exception {
 		graph.remove(alice, knows, bob);
-		assertEquals(7, graph.size());	
+		assertEquals(7, graph.size());
 		graph.remove(alice, knows, bob);
 		assertEquals(7, graph.size());
 		graph.add(alice, knows, bob);
 		graph.add(alice, knows, bob);
 		graph.add(alice, knows, bob);
 		// Undetermined size at this point
-		//assertEquals(8, graph.size());
+		// assertEquals(8, graph.size());
 		// but at least after remove they should all be gone
 		graph.remove(alice, knows, bob);
 		assertEquals(7, graph.size());
+
+		Triple otherTriple = graph.getTriples().findAny().get();
+		graph.remove(otherTriple);
+		assertEquals(6, graph.size());
+		graph.remove(otherTriple);
+		assertEquals(6, graph.size());
+		graph.add(otherTriple);
+		assertEquals(7, graph.size());
 	}
-	
+
 	@Test
-	public void something() throws Exception {
-	}		
+	public void clear() throws Exception {
+		graph.clear();
+		assertFalse(graph.contains(alice, knows, bob));
+		assertEquals(0, graph.size());
+		graph.clear(); // no-op
+		assertEquals(0, graph.size());
 	}
-	
-	
+
+	@Test
+	public void getTriples() throws Exception {
+		assertEquals(8, graph.getTriples().count());
+		assertTrue(graph.getTriples().allMatch(t -> graph.contains(t)));
+	}
+
+	@Test
+	public void getTriplesQuery() throws Exception {
+		assertEquals(3, graph.getTriples(alice, null, null).count());
+		assertEquals(4, graph.getTriples(null, name, null).count());
+
+		Set<RDFTerm> orgMembers = graph.getTriples(null, member, org1)
+				.map(Triple::getObject).collect(Collectors.toSet());
+		assertTrue(orgMembers.contains(alice));
+		assertTrue(orgMembers.contains(bob));
+	}
+
+	/**
+	 * An attempt to use the Java 8 streams to look up a more complicated query.
+	 * 
+	 * FYI, the equivalent SPARQL version (untested):
+	 * 
+	 * <pre>
+	 * 	SELECT ?orgName WHERE { 
+	 * 			?org foaf:name ?orgName .
+	 * 			?alice foaf:member ?org .
+	 * 			?bob foaf:member ?org .
+	 * 			?alice foaf:knows ?bob .
+	 * 		  FILTER NOT EXIST { ?bob foaf:knows ?alice }
+	 * 	}
+	 * </pre>
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void whyJavaStreamsMightNotTakeOverFromSparql() throws Exception {
+
+		// Find a secret organizations
+		assertEquals(
+				"\"The Secret Club\"",
+				graph.getTriples(null, knows, null)
+						// Find One-way "knows"
+						.filter(t -> !graph.contains(
+								(BlankNodeOrIRI) t.getObject(), knows,
+								t.getSubject()))
+						.map(knowsTriple -> graph
+								// and those they know, what are they member of?
+								.getTriples(
+										(BlankNodeOrIRI) knowsTriple
+												.getObject(), member, null)
+								// keep those which first-guy is a member of
+								.filter(memberTriple -> graph.contains(
+										knowsTriple.getSubject(), member,
+										// First hit is good enough
+										memberTriple.getObject())).findFirst()
+								.get().getObject())
+						// then look up the name of that org
+						.map(org -> graph
+								.getTriples((BlankNodeOrIRI) org, name, null)
+								.findFirst().get().getObject().ntriplesString())
+						.findFirst().get());
+
+	}
 }

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,29 +32,39 @@ public abstract class AbstractGraphTest {
 	private IRI member;
 	private BlankNode org1;
 	private BlankNode org2;
+	private RDFTerm aliceName;
+	private Literal bobName;
+	private Triple bobNameTriple;
 
 	public abstract RDFTermFactory createFactory();
 
 	@Before
 	public void createGraphAndAdd() {
 		factory = createFactory();
-		graph = factory.createGraph();
+		try {
+			graph = factory.createGraph();
+			alice = factory.createIRI("http://example.com/alice");
+			bob = factory.createIRI("http://example.com/bob");
+			name = factory.createIRI("http://xmlns.com/foaf/0.1/name");
+			knows = factory.createIRI("http://xmlns.com/foaf/0.1/knows");
+			member = factory.createIRI("http://xmlns.com/foaf/0.1/member");
+			org1 = factory.createBlankNode("org1");
+			org2 = factory.createBlankNode("org2");
+			aliceName = factory.createLiteral("Alice");
+			bobName = factory.createLiteral("Bob", "en-US");
+			bobNameTriple = factory.createTriple(bob, name, bobName);
+
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+		}
+
 		assertEquals(0, graph.size());
 
-		alice = factory.createIRI("http://example.com/alice");
-		bob = factory.createIRI("http://example.com/bob");
-		name = factory.createIRI("http://xmlns.com/foaf/0.1/name");
-		knows = factory.createIRI("http://xmlns.com/foaf/0.1/knows");
-		member = factory.createIRI("http://xmlns.com/foaf/0.1/member");
-		org1 = factory.createBlankNode("org1");
-		org2 = factory.createBlankNode("org2");
-
-		graph.add(alice, name, factory.createLiteral("Alice"));
+		graph.add(alice, name, aliceName);
 		graph.add(alice, knows, bob);
 		graph.add(alice, member, org1);
 		// and for Bob we'll try as Triples
-		graph.add(factory.createTriple(bob, name,
-				factory.createLiteral("Bob", "en-US")));
+		graph.add(bobNameTriple);
 		graph.add(factory.createTriple(bob, member, org1));
 		graph.add(factory.createTriple(bob, member, org2));
 

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -107,7 +107,7 @@ public abstract class AbstractGraphTest {
 			graph.add(factory.createTriple(bob, member, org2));
 			if (secretClubName != null) {
 				graph.add(org1, name, secretClubName);
-				graph.add(org1, name, companyName);
+				graph.add(org2, name, companyName);
 			}
 		}
 	}
@@ -121,7 +121,7 @@ public abstract class AbstractGraphTest {
 				.startsWith(
 						"<http://example.com/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" ."));
 		assertTrue(graph.toString().endsWith(
-				"_:org1 <http://xmlns.com/foaf/0.1/name> \"A company\" ."));
+				"_:org2 <http://xmlns.com/foaf/0.1/name> \"A company\" ."));
 
 	}
 

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -142,11 +142,7 @@ public abstract class AbstractGraphTest {
 	public void getTriplesQuery() throws Exception {
 		assertEquals(3, graph.getTriples(alice, null, null).count());
 		assertEquals(4, graph.getTriples(null, name, null).count());
-
-		Set<RDFTerm> orgMembers = graph.getTriples(null, member, org1)
-				.map(Triple::getObject).collect(Collectors.toSet());
-		assertTrue(orgMembers.contains(alice));
-		assertTrue(orgMembers.contains(bob));
+		assertEquals(2, graph.getTriples(null, member, org1).count());
 	}
 
 	/**

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -17,9 +17,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -88,6 +85,7 @@ public abstract class AbstractGraphTest {
 
 		assertTrue(graph.contains(alice, knows, bob));
 
+		@SuppressWarnings("unused")
 		Triple triple = factory.createTriple(alice, knows, bob);
 		// FIXME: Should not this be true?
 		// assertTrue(graph.contains(triple));

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -23,6 +23,20 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.github.commonsrdf.dummyimpl.DummyGraphTest;
+
+/**
+ * Test Graph implementation
+ * <p>
+ * To add to your implementation's tests, create a subclass with a name ending
+ * in <code>Test</code> and provide {@link #createFactory()} which minimally
+ * must support {@link RDFTermFactory#createGraph()} and
+ * {@link RDFTermFactory#createIRI(String)}, but ideally support all operations.
+ *
+ * @see Graph
+ * @see RDFTermFactory
+ * @see DummyGraphTest
+ */
 public abstract class AbstractGraphTest {
 
 	private RDFTermFactory factory;

--- a/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.api;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -85,19 +85,27 @@ public abstract class AbstractRDFTermFactoryTest {
 
 		// Therefore the below is disabled as a required test:
 
-		/*
-		IRI relative = factory.createIRI("../relative");
-		assertEquals("../relative", relative.getIRIString());
-		assertEquals("<../relative>", relative.ntriplesString());
+		boolean relativeIriSupported;
+		try {
+			factory.createIRI("../relative");
+			relativeIriSupported = true;
+		} catch (UnsupportedOperationException|IllegalArgumentException ex) {
+			relativeIriSupported = false;			
+		}
+		if (relativeIriSupported) {		
+			IRI relative = factory.createIRI("../relative");
+			assertEquals("../relative", relative.getIRIString());
+			assertEquals("<../relative>", relative.ntriplesString());
+	
+			IRI relativeTerm = factory.createIRI("../relative#term");
+			assertEquals("../relative#term", relativeTerm.getIRIString());
+			assertEquals("<../relative#term>", relativeTerm.ntriplesString());
+	
+			IRI emptyRelative = factory.createIRI(""); // <> equals the base URI
+			assertEquals("", emptyRelative.getIRIString());
+			assertEquals("<>", emptyRelative.ntriplesString());
+		}
 
-		IRI relativeTerm = factory.createIRI("../relative#term");
-		assertEquals("../relative#term", relativeTerm.getIRIString());
-		assertEquals("<../relative#term>", relativeTerm.ntriplesString());
-
-		IRI emptyRelative = factory.createIRI(""); // <> equals the base URI
-		assertEquals("", emptyRelative.getIRIString());
-		assertEquals("<>", emptyRelative.ntriplesString());
-		*/
 
 		// and now for the international fun!
 

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -221,9 +221,9 @@ public abstract class AbstractRDFTermFactoryTest {
 		factory = createFactory();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = Exception.class)
 	public void invalidBlankNode() throws Exception {
-		factory.createBlankNode("with:colon");
+		factory.createBlankNode("with:colon").ntriplesString();
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -23,6 +23,18 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.github.commonsrdf.dummyimpl.DummyRDFTermFactoryTest;
+
+/**
+ * Test RDFTermFactory implementation (and thus its RDFTerm implementations)
+ * <p>
+ * To add to your implementation's tests, create a subclass with a name ending
+ * in <code>Test</code> and provide {@link #createFactory()} which minimally
+ * supports one of the operations, but ideally supports all operations.
+ * 
+ * @see RDFTermFactory
+ * @see DummyRDFTermFactoryTest
+ */
 public abstract class AbstractRDFTermFactoryTest {
 
 	private RDFTermFactory factory;

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public abstract class AbstractRDFTermFactoryTest {

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
-public abstract class AbstractCommonsRDFTest {
+public abstract class AbstractRDFTermFactoryTest {
 
 	private RDFTermFactory factory;
 
@@ -220,5 +220,5 @@ public abstract class AbstractCommonsRDFTest {
 		BlankNode object = factory.createBlankNode("b3");
 		factory.createTriple(subject, (IRI) predicate, object);
 	}
-
+	
 }

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -77,6 +77,15 @@ public abstract class AbstractRDFTermFactoryTest {
 		assertEquals("http://example.com/vocab#term", term.getIRIString());
 		assertEquals("<http://example.com/vocab#term>", term.ntriplesString());
 
+		// Although relative IRIs are defined in 
+		// http://www.w3.org/TR/rdf11-concepts/#section-IRIs
+		// it is not a requirement for an implementation to support
+		// it (all instances of an relative IRI should eventually
+		// be possible to resolve to an absolute IRI)
+
+		// Therefore the below is disabled as a required test:
+
+		/*
 		IRI relative = factory.createIRI("../relative");
 		assertEquals("../relative", relative.getIRIString());
 		assertEquals("<../relative>", relative.ntriplesString());
@@ -88,6 +97,7 @@ public abstract class AbstractRDFTermFactoryTest {
 		IRI emptyRelative = factory.createIRI(""); // <> equals the base URI
 		assertEquals("", emptyRelative.getIRIString());
 		assertEquals("<>", emptyRelative.ntriplesString());
+		*/
 
 		// and now for the international fun!
 

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -78,8 +78,6 @@ public abstract class AbstractRDFTermFactoryTest {
 		assertEquals("http://example.com/vocab#term", term.getIRIString());
 		assertEquals("<http://example.com/vocab#term>", term.ntriplesString());
 
-
-
 		// and now for the international fun!
 
 		IRI latin1 = factory.createIRI("http://accént.example.com/première");
@@ -98,10 +96,10 @@ public abstract class AbstractRDFTermFactoryTest {
 		assertEquals("http://𐐀.example.com/𐐀", deseret.getIRIString());
 		assertEquals("<http://𐐀.example.com/𐐀>", deseret.ntriplesString());
 	}
-	
+
 	@Test
 	public void createIRIRelative() throws Exception {
-		// Although relative IRIs are defined in 
+		// Although relative IRIs are defined in
 		// http://www.w3.org/TR/rdf11-concepts/#section-IRIs
 		// it is not a requirement for an implementation to support
 		// it (all instances of an relative IRI should eventually
@@ -109,10 +107,11 @@ public abstract class AbstractRDFTermFactoryTest {
 
 		try {
 			factory.createIRI("../relative");
-		} catch (UnsupportedOperationException|IllegalArgumentException ex) {
+		} catch (UnsupportedOperationException | IllegalArgumentException ex) {
 			// Therefore the below simply skips the test if the
 			// above fails
-			Assume.assumeNoException("Ignoring unsupported Relative IRI (not a failure)", ex);
+			Assume.assumeNoException(
+					"Ignoring unsupported Relative IRI (not a failure)", ex);
 		}
 		IRI relative = factory.createIRI("../relative");
 		assertEquals("../relative", relative.getIRIString());
@@ -126,7 +125,7 @@ public abstract class AbstractRDFTermFactoryTest {
 		assertEquals("", emptyRelative.getIRIString());
 		assertEquals("<>", emptyRelative.ntriplesString());
 	}
-	
+
 	@Test
 	public void createLiteral() throws Exception {
 		Literal example = factory.createLiteral("Example");
@@ -252,5 +251,5 @@ public abstract class AbstractRDFTermFactoryTest {
 		BlankNode object = factory.createBlankNode("b3");
 		factory.createTriple(subject, (IRI) predicate, object);
 	}
-	
+
 }

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -19,7 +19,9 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public abstract class AbstractRDFTermFactoryTest {
@@ -77,34 +79,6 @@ public abstract class AbstractRDFTermFactoryTest {
 		assertEquals("http://example.com/vocab#term", term.getIRIString());
 		assertEquals("<http://example.com/vocab#term>", term.ntriplesString());
 
-		// Although relative IRIs are defined in 
-		// http://www.w3.org/TR/rdf11-concepts/#section-IRIs
-		// it is not a requirement for an implementation to support
-		// it (all instances of an relative IRI should eventually
-		// be possible to resolve to an absolute IRI)
-
-		// Therefore the below is disabled as a required test:
-
-		boolean relativeIriSupported;
-		try {
-			factory.createIRI("../relative");
-			relativeIriSupported = true;
-		} catch (UnsupportedOperationException|IllegalArgumentException ex) {
-			relativeIriSupported = false;			
-		}
-		if (relativeIriSupported) {		
-			IRI relative = factory.createIRI("../relative");
-			assertEquals("../relative", relative.getIRIString());
-			assertEquals("<../relative>", relative.ntriplesString());
-	
-			IRI relativeTerm = factory.createIRI("../relative#term");
-			assertEquals("../relative#term", relativeTerm.getIRIString());
-			assertEquals("<../relative#term>", relativeTerm.ntriplesString());
-	
-			IRI emptyRelative = factory.createIRI(""); // <> equals the base URI
-			assertEquals("", emptyRelative.getIRIString());
-			assertEquals("<>", emptyRelative.ntriplesString());
-		}
 
 
 		// and now for the international fun!
@@ -125,7 +99,35 @@ public abstract class AbstractRDFTermFactoryTest {
 		assertEquals("http://𐐀.example.com/𐐀", deseret.getIRIString());
 		assertEquals("<http://𐐀.example.com/𐐀>", deseret.ntriplesString());
 	}
+	
+	@Test
+	public void createIRIRelative() throws Exception {
+		// Although relative IRIs are defined in 
+		// http://www.w3.org/TR/rdf11-concepts/#section-IRIs
+		// it is not a requirement for an implementation to support
+		// it (all instances of an relative IRI should eventually
+		// be possible to resolve to an absolute IRI)
 
+		try {
+			factory.createIRI("../relative");
+		} catch (UnsupportedOperationException|IllegalArgumentException ex) {
+			// Therefore the below simply skips the test if the
+			// above fails
+			Assume.assumeNoException("Ignoring unsupported Relative IRI (not a failure)", ex);
+		}
+		IRI relative = factory.createIRI("../relative");
+		assertEquals("../relative", relative.getIRIString());
+		assertEquals("<../relative>", relative.ntriplesString());
+
+		IRI relativeTerm = factory.createIRI("../relative#term");
+		assertEquals("../relative#term", relativeTerm.getIRIString());
+		assertEquals("<../relative#term>", relativeTerm.ntriplesString());
+
+		IRI emptyRelative = factory.createIRI(""); // <> equals the base URI
+		assertEquals("", emptyRelative.getIRIString());
+		assertEquals("<>", emptyRelative.ntriplesString());
+	}
+	
 	@Test
 	public void createLiteral() throws Exception {
 		Literal example = factory.createLiteral("Example");

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -29,7 +29,13 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createBlankNode() throws Exception {
-		BlankNode bnode = factory.createBlankNode();
+		BlankNode bnode;
+		try {
+			bnode = factory.createBlankNode();
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
 		String ntriplesString = bnode.ntriplesString();
 		assertTrue("ntriples must start with _:",
 				ntriplesString.startsWith("_:"));
@@ -47,7 +53,13 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createBlankNodeIdentifier() throws Exception {
-		BlankNode bnode = factory.createBlankNode("example1");
+		BlankNode bnode;
+		try {
+			bnode = factory.createBlankNode("example1");
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
 		assertEquals("example1", bnode.internalIdentifier());
 		assertEquals("_:example1", bnode.ntriplesString());
 	}
@@ -56,7 +68,14 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createGraph() {
-		Graph graph = factory.createGraph();
+		Graph graph;
+		try {
+			graph = factory.createGraph();
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
+
 		assertEquals("Graph was not empty", 0, graph.size());
 		graph.add(factory.createBlankNode(),
 				factory.createIRI("http://example.com/"),
@@ -70,7 +89,14 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createIRI() throws Exception {
-		IRI example = factory.createIRI("http://example.com/");
+		IRI example;
+		try {
+			example = factory.createIRI("http://example.com/");
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException("createIRI not supported", ex);
+			return;
+		}
+
 		assertEquals("http://example.com/", example.getIRIString());
 		assertEquals("<http://example.com/>", example.ntriplesString());
 
@@ -104,14 +130,11 @@ public abstract class AbstractRDFTermFactoryTest {
 		// it is not a requirement for an implementation to support
 		// it (all instances of an relative IRI should eventually
 		// be possible to resolve to an absolute IRI)
-
 		try {
 			factory.createIRI("../relative");
 		} catch (UnsupportedOperationException | IllegalArgumentException ex) {
-			// Therefore the below simply skips the test if the
-			// above fails
-			Assume.assumeNoException(
-					"Ignoring unsupported Relative IRI (not a failure)", ex);
+			Assume.assumeNoException(ex);
+			return;
 		}
 		IRI relative = factory.createIRI("../relative");
 		assertEquals("../relative", relative.getIRIString());
@@ -128,7 +151,14 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createLiteral() throws Exception {
-		Literal example = factory.createLiteral("Example");
+		Literal example;
+		try {
+			example = factory.createLiteral("Example");
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
+
 		assertEquals("Example", example.getLexicalForm());
 		assertFalse(example.getLanguageTag().isPresent());
 		assertEquals("http://www.w3.org/2001/XMLSchema#string", example
@@ -139,8 +169,15 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createLiteralDateTime() throws Exception {
-		Literal dateTime = factory.createLiteral("2014-12-27T00:50:00T-0600",
-				factory.createIRI("http://www.w3.org/2001/XMLSchema#dateTime"));
+		Literal dateTime;
+		try {
+			dateTime = factory.createLiteral(
+							"2014-12-27T00:50:00T-0600",
+							factory.createIRI("http://www.w3.org/2001/XMLSchema#dateTime"));
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
 		assertEquals("2014-12-27T00:50:00T-0600", dateTime.getLexicalForm());
 		assertFalse(dateTime.getLanguageTag().isPresent());
 		assertEquals("http://www.w3.org/2001/XMLSchema#dateTime", dateTime
@@ -152,7 +189,14 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createLiteralLang() throws Exception {
-		Literal example = factory.createLiteral("Example", "en");
+		Literal example;
+		try {
+			example = factory.createLiteral("Example", "en");
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
+
 		assertEquals("Example", example.getLexicalForm());
 		assertEquals("en", example.getLanguageTag().get());
 		assertEquals("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
@@ -162,8 +206,14 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createLiteralString() throws Exception {
-		Literal example = factory.createLiteral("Example",
-				factory.createIRI("http://www.w3.org/2001/XMLSchema#string"));
+		Literal example;
+		try {
+			example = factory.createLiteral("Example", factory
+					.createIRI("http://www.w3.org/2001/XMLSchema#string"));
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
 		assertEquals("Example", example.getLexicalForm());
 		assertFalse(example.getLanguageTag().isPresent());
 		assertEquals("http://www.w3.org/2001/XMLSchema#string", example
@@ -174,10 +224,19 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createTripleBnodeBnode() {
-		BlankNode subject = factory.createBlankNode("b1");
-		IRI predicate = factory.createIRI("http://example.com/pred");
-		BlankNode object = factory.createBlankNode("b2");
-		Triple triple = factory.createTriple(subject, predicate, object);
+		BlankNode subject;
+		IRI predicate;
+		BlankNode object;
+		Triple triple;
+		try {
+			subject = factory.createBlankNode("b1");
+			predicate = factory.createIRI("http://example.com/pred");
+			object = factory.createBlankNode("b2");
+			triple = factory.createTriple(subject, predicate, object);
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
 
 		// NOTE: We do not require object equivalence after insertion,
 		// but the ntriples should match
@@ -192,10 +251,19 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createTripleBnodeIRI() {
-		BlankNode subject = factory.createBlankNode("b1");
-		IRI predicate = factory.createIRI("http://example.com/pred");
-		IRI object = factory.createIRI("http://example.com/obj");
-		Triple triple = factory.createTriple(subject, predicate, object);
+		BlankNode subject;
+		IRI predicate;
+		IRI object;
+		Triple triple;
+		try {
+			subject = factory.createBlankNode("b1");
+			predicate = factory.createIRI("http://example.com/pred");
+			object = factory.createIRI("http://example.com/obj");
+			triple = factory.createTriple(subject, predicate, object);
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
 
 		// NOTE: We do not require object equivalence after insertion,
 		// but the ntriples should match
@@ -209,10 +277,19 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createTripleBnodeTriple() {
-		BlankNode subject = factory.createBlankNode();
-		IRI predicate = factory.createIRI("http://example.com/pred");
-		Literal object = factory.createLiteral("Example", "en");
-		Triple triple = factory.createTriple(subject, predicate, object);
+		BlankNode subject;
+		IRI predicate;
+		Literal object;
+		Triple triple;
+		try {
+			subject = factory.createBlankNode();
+			predicate = factory.createIRI("http://example.com/pred");
+			object = factory.createLiteral("Example", "en");
+			triple = factory.createTriple(subject, predicate, object);
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
 
 		// NOTE: We do not require object equivalence after insertion,
 		// but the ntriples should match
@@ -231,17 +308,34 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test(expected = Exception.class)
 	public void invalidBlankNode() throws Exception {
-		factory.createBlankNode("with:colon").ntriplesString();
+		try {
+			factory.createBlankNode("with:colon").ntriplesString();
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException("createBlankNode(String) not supported",
+					ex);
+			return;
+		}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void invalidIRI() throws Exception {
-		factory.createIRI("<no_brackets>");
+		try {
+			factory.createIRI("<no_brackets>");
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException("createIRI not supported", ex);
+			return;
+		}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void invalidLiteralLang() throws Exception {
-		factory.createLiteral("Example", "");
+		try {
+			factory.createLiteral("Example", "");
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(
+					"createLiteral(String,String) not supported", ex);
+			return;
+		}
 	}
 
 	@Test(expected = Exception.class)

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -214,6 +214,27 @@ public abstract class AbstractRDFTermFactoryTest {
 		assertEquals("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
 				example.getDatatype().getIRIString());
 		assertEquals("\"Example\"@en", example.ntriplesString());
+		
+		// What about more exotic ISO-639-3 languages?
+		factory.createLiteral("Herbert Van de Sompel", "vls"); // JENA-827 reference
+	}
+	
+
+	@Test
+	public void createLiteralLangISO693_3() throws Exception {
+		// see https://issues.apache.org/jira/browse/JENA-827
+		Literal vls;
+		try {
+			vls = factory.createLiteral("Herbert Van de Sompel", "vls"); // JENA-827 reference
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
+
+		assertEquals("vls", vls.getLanguageTag().get());
+		assertEquals("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
+				vls.getDatatype().getIRIString());
+		assertEquals("\"Herbert Van de Sompel\"@vls", vls.ntriplesString());
 	}
 
 	@Test
@@ -342,7 +363,7 @@ public abstract class AbstractRDFTermFactoryTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void invalidLiteralLang() throws Exception {
 		try {
-			factory.createLiteral("Example", "");
+			factory.createLiteral("Example", "with space");
 		} catch (UnsupportedOperationException ex) {
 			Assume.assumeNoException(
 					"createLiteral(String,String) not supported", ex);

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -214,18 +214,15 @@ public abstract class AbstractRDFTermFactoryTest {
 		assertEquals("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
 				example.getDatatype().getIRIString());
 		assertEquals("\"Example\"@en", example.ntriplesString());
-		
-		// What about more exotic ISO-639-3 languages?
-		factory.createLiteral("Herbert Van de Sompel", "vls"); // JENA-827 reference
 	}
-	
 
 	@Test
 	public void createLiteralLangISO693_3() throws Exception {
 		// see https://issues.apache.org/jira/browse/JENA-827
 		Literal vls;
 		try {
-			vls = factory.createLiteral("Herbert Van de Sompel", "vls"); // JENA-827 reference
+			vls = factory.createLiteral("Herbert Van de Sompel", "vls"); // JENA-827
+																			// reference
 		} catch (UnsupportedOperationException ex) {
 			Assume.assumeNoException(ex);
 			return;

--- a/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.api;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
+++ b/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
@@ -11,14 +11,14 @@ package com.github.commonsrdf.api;
  * 
  */
 public interface RDFTermFactory {
-	public Graph createGraph() throws UnsupportedOperationException;
-
-	public IRI createIRI(String iri) throws UnsupportedOperationException;
-
 	public BlankNode createBlankNode() throws UnsupportedOperationException;
 
 	public BlankNode createBlankNode(String identifier)
 			throws UnsupportedOperationException;
+
+	public Graph createGraph() throws UnsupportedOperationException;
+
+	public IRI createIRI(String iri) throws UnsupportedOperationException;
 
 	public Literal createLiteral(String literal)
 			throws UnsupportedOperationException;

--- a/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
+++ b/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.api;
 
 /**

--- a/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
+++ b/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
@@ -17,7 +17,11 @@ package com.github.commonsrdf.api;
  * Factory for creating RDFTerm and Graph instances.
  * <p>
  * If an implementation does not support a particular method (e.g. because it
- * needs more parameters), then it may throw UnsupportedOperationException.
+ * needs more parameters), then it MAY throw UnsupportedOperationException.
+ * <p>
+ * If a factory method does not allow a provided parameter, e.g. because an IRI
+ * is invalid, then it SHOULD throw IllegalArgumentException.
+ * 
  * 
  * @see RDFTerm
  * @see Graph
@@ -31,16 +35,17 @@ public interface RDFTermFactory {
 
 	public Graph createGraph() throws UnsupportedOperationException;
 
-	public IRI createIRI(String iri) throws UnsupportedOperationException;
+	public IRI createIRI(String iri) throws UnsupportedOperationException,
+			IllegalArgumentException;
 
 	public Literal createLiteral(String literal)
 			throws UnsupportedOperationException;
 
 	public Literal createLiteral(String literal, IRI dataType)
-			throws UnsupportedOperationException;
+			throws UnsupportedOperationException, IllegalArgumentException;
 
 	public Literal createLiteral(String literal, String language)
-			throws UnsupportedOperationException;
+			throws UnsupportedOperationException, IllegalArgumentException;
 
 	public Triple createTriple(BlankNodeOrIRI subject, IRI predicate,
 			RDFTerm object) throws UnsupportedOperationException;

--- a/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
+++ b/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
@@ -12,12 +12,24 @@ package com.github.commonsrdf.api;
  */
 public interface RDFTermFactory {
 	public Graph createGraph() throws UnsupportedOperationException;
+
 	public IRI createIRI(String iri) throws UnsupportedOperationException;
+
 	public BlankNode createBlankNode() throws UnsupportedOperationException;
-	public BlankNode createBlankNode(String identifier) throws UnsupportedOperationException;	
-	public Literal createLiteral(String literal) throws UnsupportedOperationException;
-	public Literal createLiteral(String literal, IRI dataType) throws UnsupportedOperationException;
-	public Literal createLiteral(String literal, String language) throws UnsupportedOperationException;
-	public Triple createTriple(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) throws UnsupportedOperationException;
+
+	public BlankNode createBlankNode(String identifier)
+			throws UnsupportedOperationException;
+
+	public Literal createLiteral(String literal)
+			throws UnsupportedOperationException;
+
+	public Literal createLiteral(String literal, IRI dataType)
+			throws UnsupportedOperationException;
+
+	public Literal createLiteral(String literal, String language)
+			throws UnsupportedOperationException;
+
+	public Triple createTriple(BlankNodeOrIRI subject, IRI predicate,
+			RDFTerm object) throws UnsupportedOperationException;
 
 }

--- a/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
+++ b/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java
@@ -17,10 +17,11 @@ package com.github.commonsrdf.api;
  * Factory for creating RDFTerm and Graph instances.
  * <p>
  * If an implementation does not support a particular method (e.g. because it
- * needs more parameters), then it MAY throw UnsupportedOperationException.
+ * needs more parameters or can't create graphs), then it MAY throw
+ * UnsupportedOperationException (as provided by the default implementations).
  * <p>
- * If a factory method does not allow a provided parameter, e.g. because an IRI
- * is invalid, then it SHOULD throw IllegalArgumentException.
+ * If a factory method does not allow or support a provided parameter, e.g.
+ * because an IRI is invalid, then it SHOULD throw IllegalArgumentException.
  * 
  * 
  * @see RDFTerm
@@ -28,26 +29,50 @@ package com.github.commonsrdf.api;
  * 
  */
 public interface RDFTermFactory {
-	public BlankNode createBlankNode() throws UnsupportedOperationException;
+	default BlankNode createBlankNode() throws UnsupportedOperationException {
+		throw new UnsupportedOperationException(
+				"createBlankNode() not supported");
+	}
 
-	public BlankNode createBlankNode(String identifier)
-			throws UnsupportedOperationException;
+	default BlankNode createBlankNode(String identifier)
+			throws UnsupportedOperationException {
+		throw new UnsupportedOperationException(
+				"createBlankNode(String) not supported");
+	}
 
-	public Graph createGraph() throws UnsupportedOperationException;
+	default Graph createGraph() throws UnsupportedOperationException {
+		throw new UnsupportedOperationException("createGraph() not supported");
+	}
 
-	public IRI createIRI(String iri) throws UnsupportedOperationException,
-			IllegalArgumentException;
+	default IRI createIRI(String iri) throws UnsupportedOperationException,
+			IllegalArgumentException {
+		throw new UnsupportedOperationException(
+				"createIRI(String) not supported");
+	}
 
-	public Literal createLiteral(String literal)
-			throws UnsupportedOperationException;
+	default Literal createLiteral(String literal)
+			throws UnsupportedOperationException {
+		throw new UnsupportedOperationException(
+				"createLiteral(String) not supported");
+	}
 
-	public Literal createLiteral(String literal, IRI dataType)
-			throws UnsupportedOperationException, IllegalArgumentException;
+	default Literal createLiteral(String literal, IRI dataType)
+			throws UnsupportedOperationException, IllegalArgumentException {
+		throw new UnsupportedOperationException(
+				"createLiteral(String) not supported");
+	}
 
-	public Literal createLiteral(String literal, String language)
-			throws UnsupportedOperationException, IllegalArgumentException;
+	default Literal createLiteral(String literal, String language)
+			throws UnsupportedOperationException, IllegalArgumentException {
+		throw new UnsupportedOperationException(
+				"createLiteral(String,String) not supported");
+	}
 
-	public Triple createTriple(BlankNodeOrIRI subject, IRI predicate,
-			RDFTerm object) throws UnsupportedOperationException;
+	default Triple createTriple(BlankNodeOrIRI subject, IRI predicate,
+			RDFTerm object) throws UnsupportedOperationException,
+			IllegalArgumentException {
+		throw new UnsupportedOperationException(
+				"createTriple(BlankNodeOrIRI,IRI,RDFTerm) not supported");
+	}
 
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
@@ -30,7 +30,7 @@ public class BlankNodeImpl implements BlankNode {
 		this(Optional.empty(), "b" + bnodeCounter.incrementAndGet());
 	}
 
-	public BlankNodeImpl(Optional<Graph> localScope, String id) {		
+	public BlankNodeImpl(Optional<Graph> localScope, String id) {
 		this.localScope = Objects.requireNonNull(localScope);
 		if (Objects.requireNonNull(id).isEmpty()) {
 			throw new IllegalArgumentException("Invalid blank node id: " + id);

--- a/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.dummyimpl;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
@@ -23,13 +23,13 @@ public class BlankNodeImpl implements BlankNode {
 	}
 
 	@Override
-	public String ntriplesString() {
-		return "_:" + id;
+	public String internalIdentifier() {
+		return id;
 	}
 
 	@Override
-	public String internalIdentifier() {
-		return id;
+	public String ntriplesString() {
+		return "_:" + id;
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
@@ -8,14 +8,15 @@ public class BlankNodeImpl implements BlankNode {
 
 	private static AtomicLong bnodeCounter = new AtomicLong();
 	private String id;
-	
-	public BlankNodeImpl() { 
+
+	public BlankNodeImpl() {
 		this("b" + bnodeCounter.incrementAndGet());
 	}
-	
+
 	public BlankNodeImpl(String id) {
 		if (id == null || id.isEmpty() || id.contains(":")) {
-			// TODO: Check against http://www.w3.org/TR/n-triples/#n-triples-grammar
+			// TODO: Check against
+			// http://www.w3.org/TR/n-triples/#n-triples-grammar
 			throw new IllegalArgumentException("Invalid blank node id: " + id);
 		}
 		this.id = id;
@@ -30,7 +31,7 @@ public class BlankNodeImpl implements BlankNode {
 	public String internalIdentifier() {
 		return id;
 	}
-	
+
 	@Override
 	public String toString() {
 		return ntriplesString();

--- a/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
@@ -13,6 +13,8 @@
  */
 package com.github.commonsrdf.dummyimpl;
 
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.github.commonsrdf.api.BlankNode;
@@ -22,18 +24,18 @@ public class BlankNodeImpl implements BlankNode {
 
 	private static AtomicLong bnodeCounter = new AtomicLong();
 	private String id;
-	private Graph localScope;
+	private Optional<Graph> localScope;
 
 	public BlankNodeImpl() {
-		this(null, "b" + bnodeCounter.incrementAndGet());
+		this(Optional.empty(), "b" + bnodeCounter.incrementAndGet());
 	}
 
-	public BlankNodeImpl(Graph localScope, String id) {
-		this.localScope = localScope;
-		if (id == null || id.isEmpty()) {
-			// TODO: Check against
-			// http://www.w3.org/TR/n-triples/#n-triples-grammar
+	public BlankNodeImpl(Optional<Graph> localScope, String id) {		
+		this.localScope = Objects.requireNonNull(localScope);
+		if (Objects.requireNonNull(id).isEmpty()) {
 			throw new IllegalArgumentException("Invalid blank node id: " + id);
+			// NOTE: It is valid for the id to not be a valid ntriples bnode id.
+			// See ntriplesString().
 		}
 		this.id = id;
 	}
@@ -46,6 +48,7 @@ public class BlankNodeImpl implements BlankNode {
 	@Override
 	public String ntriplesString() {
 		if (id.contains(":")) {
+			// FIXME: Perhaps do a SHA hash of the id?
 			throw new IllegalStateException(
 					"Blank node identifier can't be expressed as ntriples string: "
 							+ id);

--- a/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
@@ -16,17 +16,20 @@ package com.github.commonsrdf.dummyimpl;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.github.commonsrdf.api.BlankNode;
+import com.github.commonsrdf.api.Graph;
 
 public class BlankNodeImpl implements BlankNode {
 
 	private static AtomicLong bnodeCounter = new AtomicLong();
 	private String id;
+	private Graph localScope;
 
 	public BlankNodeImpl() {
-		this("b" + bnodeCounter.incrementAndGet());
+		this(null, "b" + bnodeCounter.incrementAndGet());
 	}
 
-	public BlankNodeImpl(String id) {
+	public BlankNodeImpl(Graph localScope, String id) {
+		this.localScope = localScope;
 		if (id == null || id.isEmpty()) {
 			// TODO: Check against
 			// http://www.w3.org/TR/n-triples/#n-triples-grammar
@@ -53,6 +56,45 @@ public class BlankNodeImpl implements BlankNode {
 	@Override
 	public String toString() {
 		return ntriplesString();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result
+				+ ((localScope == null) ? 0 : localScope.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof BlankNodeImpl)) {
+			return false;
+		}
+		BlankNodeImpl other = (BlankNodeImpl) obj;
+		if (id == null) {
+			if (other.id != null) {
+				return false;
+			}
+		} else if (!id.equals(other.id)) {
+			return false;
+		}
+		if (localScope == null) {
+			if (other.localScope != null) {
+				return false;
+			}
+		} else if (!localScope.equals(other.localScope)) {
+			return false;
+		}
+		return true;
 	}
 
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
@@ -63,12 +63,7 @@ public class BlankNodeImpl implements BlankNode {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		result = prime * result
-				+ ((localScope == null) ? 0 : localScope.hashCode());
-		return result;
+		return Objects.hash(localScope, id);
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/BlankNodeImpl.java
@@ -27,7 +27,7 @@ public class BlankNodeImpl implements BlankNode {
 	}
 
 	public BlankNodeImpl(String id) {
-		if (id == null || id.isEmpty() || id.contains(":")) {
+		if (id == null || id.isEmpty()) {
 			// TODO: Check against
 			// http://www.w3.org/TR/n-triples/#n-triples-grammar
 			throw new IllegalArgumentException("Invalid blank node id: " + id);
@@ -42,6 +42,11 @@ public class BlankNodeImpl implements BlankNode {
 
 	@Override
 	public String ntriplesString() {
+		if (id.contains(":")) {
+			throw new IllegalStateException(
+					"Blank node identifier can't be expressed as ntriples string: "
+							+ id);
+		}
 		return "_:" + id;
 	}
 

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DefaultGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DefaultGraphTest.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.commonsrdf.dummyimpl;
+
+import com.github.commonsrdf.api.AbstractGraphTest;
+import com.github.commonsrdf.api.RDFTermFactory;
+
+/**
+ * Ensure AbstractGraphTest does not crash if the RDFTermFactory
+ * throws UnsupportedOperationException
+ *
+ */
+
+public class DefaultGraphTest extends AbstractGraphTest {
+
+	@Override
+	public RDFTermFactory createFactory() {
+		return new RDFTermFactory(){};
+	}
+
+}

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DefaultGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DefaultGraphTest.java
@@ -19,8 +19,8 @@ import com.github.commonsrdf.api.IRI;
 import com.github.commonsrdf.api.RDFTermFactory;
 
 /**
- * Ensure AbstractGraphTest does not crash if the RDFTermFactory
- * throws UnsupportedOperationException
+ * Ensure AbstractGraphTest does not crash if the RDFTermFactory throws
+ * UnsupportedOperationException
  *
  */
 
@@ -30,11 +30,12 @@ public class DefaultGraphTest extends AbstractGraphTest {
 	public RDFTermFactory createFactory() {
 		// The most minimal RDFTermFactory that would still
 		// make sense with a Graph
-		return new RDFTermFactory(){
+		return new RDFTermFactory() {
 			@Override
-			public Graph createGraph() throws UnsupportedOperationException {				
+			public Graph createGraph() throws UnsupportedOperationException {
 				return new GraphImpl();
 			}
+
 			@Override
 			public IRI createIRI(String iri)
 					throws UnsupportedOperationException,

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DefaultGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DefaultGraphTest.java
@@ -14,6 +14,8 @@
 package com.github.commonsrdf.dummyimpl;
 
 import com.github.commonsrdf.api.AbstractGraphTest;
+import com.github.commonsrdf.api.Graph;
+import com.github.commonsrdf.api.IRI;
 import com.github.commonsrdf.api.RDFTermFactory;
 
 /**
@@ -26,7 +28,20 @@ public class DefaultGraphTest extends AbstractGraphTest {
 
 	@Override
 	public RDFTermFactory createFactory() {
-		return new RDFTermFactory(){};
+		// The most minimal RDFTermFactory that would still
+		// make sense with a Graph
+		return new RDFTermFactory(){
+			@Override
+			public Graph createGraph() throws UnsupportedOperationException {				
+				return new GraphImpl();
+			}
+			@Override
+			public IRI createIRI(String iri)
+					throws UnsupportedOperationException,
+					IllegalArgumentException {
+				return new IRIImpl(iri);
+			}
+		};
 	}
 
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DefaultRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DefaultRDFTermFactoryTest.java
@@ -17,17 +17,17 @@ import com.github.commonsrdf.api.AbstractRDFTermFactoryTest;
 import com.github.commonsrdf.api.RDFTermFactory;
 
 /**
- * The default RDFTermFactory might be useless (every method throws 
- * UnsupportedOperationException), but this test ensures that 
- * AbstractRDFTermFactoryTest does not fall over on unsupported
- * operations.
+ * The default RDFTermFactory might be useless (every method throws
+ * UnsupportedOperationException), but this test ensures that
+ * AbstractRDFTermFactoryTest does not fall over on unsupported operations.
  *
  */
 public class DefaultRDFTermFactoryTest extends AbstractRDFTermFactoryTest {
 
 	@Override
-	public RDFTermFactory createFactory() {		
-		return new RDFTermFactory(){};
+	public RDFTermFactory createFactory() {
+		return new RDFTermFactory() {
+		};
 	}
 
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DefaultRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DefaultRDFTermFactoryTest.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.commonsrdf.dummyimpl;
+
+import com.github.commonsrdf.api.AbstractRDFTermFactoryTest;
+import com.github.commonsrdf.api.RDFTermFactory;
+
+/**
+ * The default RDFTermFactory might be useless (every method throws 
+ * UnsupportedOperationException), but this test ensures that 
+ * AbstractRDFTermFactoryTest does not fall over on unsupported
+ * operations.
+ *
+ */
+public class DefaultRDFTermFactoryTest extends AbstractRDFTermFactoryTest {
+
+	@Override
+	public RDFTermFactory createFactory() {		
+		return new RDFTermFactory(){};
+	}
+
+}

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyGraphTest.java
@@ -1,0 +1,13 @@
+package com.github.commonsrdf.dummyimpl;
+
+import com.github.commonsrdf.api.AbstractGraphTest;
+import com.github.commonsrdf.api.RDFTermFactory;
+
+public class DummyGraphTest extends AbstractGraphTest {
+
+	@Override
+	public RDFTermFactory createFactory() {
+		return new DummyRDFTermFactory();
+	}
+
+}

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyGraphTest.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.dummyimpl;
 
 import com.github.commonsrdf.api.AbstractGraphTest;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyGraphTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyGraphTest.java
@@ -16,6 +16,10 @@ package com.github.commonsrdf.dummyimpl;
 import com.github.commonsrdf.api.AbstractGraphTest;
 import com.github.commonsrdf.api.RDFTermFactory;
 
+/**
+ * Test DummyRDFTermFactory with AbstractGraphTest
+ *
+ */
 public class DummyGraphTest extends AbstractGraphTest {
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyNoRelativeIRIRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyNoRelativeIRIRDFTermFactoryTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.commonsrdf.dummyimpl;
+
+import java.net.URI;
+
+import com.github.commonsrdf.api.AbstractRDFTermFactoryTest;
+import com.github.commonsrdf.api.IRI;
+import com.github.commonsrdf.api.RDFTermFactory;
+
+/**
+ * Test dummy without relative IRI support.
+ * <p?>
+ * Ensures that {@link AbstractRDFTermFactoryTest#createIRIRelative()} is
+ * correctly skipped (without causing an error.
+ *
+ */
+public class DummyNoRelativeIRIRDFTermFactoryTest extends
+		AbstractRDFTermFactoryTest {
+	@Override
+	public RDFTermFactory createFactory() {
+		return new DummyRDFTermFactory() {
+			@Override
+			public IRI createIRI(String iri) {
+				if (!URI.create(iri).isAbsolute()) {
+					throw new IllegalArgumentException("IRIs must be absolute");
+					// ..in this subclass for testing purposes only :)
+				}
+				return super.createIRI(iri);
+			}
+		};
+	}
+}

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactory.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactory.java
@@ -12,16 +12,6 @@ import com.github.commonsrdf.api.Triple;
 public class DummyRDFTermFactory implements RDFTermFactory {
 
 	@Override
-	public Graph createGraph() {
-		return new GraphImpl();
-	}
-
-	@Override
-	public IRI createIRI(String iri) {
-		return new IRIImpl(iri);
-	}
-
-	@Override
 	public BlankNode createBlankNode() {
 		return new BlankNodeImpl();
 	}
@@ -29,6 +19,16 @@ public class DummyRDFTermFactory implements RDFTermFactory {
 	@Override
 	public BlankNode createBlankNode(String identifier) {
 		return new BlankNodeImpl(identifier);
+	}
+
+	@Override
+	public Graph createGraph() {
+		return new GraphImpl();
+	}
+
+	@Override
+	public IRI createIRI(String iri) {
+		return new IRIImpl(iri);
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactory.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactory.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.dummyimpl;
 
 import com.github.commonsrdf.api.BlankNode;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactory.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactory.java
@@ -13,6 +13,8 @@
  */
 package com.github.commonsrdf.dummyimpl;
 
+import java.util.Optional;
+
 import com.github.commonsrdf.api.BlankNode;
 import com.github.commonsrdf.api.BlankNodeOrIRI;
 import com.github.commonsrdf.api.Graph;
@@ -31,7 +33,7 @@ public class DummyRDFTermFactory implements RDFTermFactory {
 
 	@Override
 	public BlankNode createBlankNode(String identifier) {
-		return new BlankNodeImpl(null, identifier);
+		return new BlankNodeImpl(Optional.empty(), identifier);
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactory.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactory.java
@@ -31,7 +31,7 @@ public class DummyRDFTermFactory implements RDFTermFactory {
 
 	@Override
 	public BlankNode createBlankNode(String identifier) {
-		return new BlankNodeImpl(identifier);
+		return new BlankNodeImpl(null, identifier);
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactoryTest.java
@@ -1,9 +1,9 @@
 package com.github.commonsrdf.dummyimpl;
 
-import com.github.commonsrdf.api.AbstractCommonsRDFTest;
+import com.github.commonsrdf.api.AbstractRDFTermFactoryTest;
 import com.github.commonsrdf.api.RDFTermFactory;
 
-public class DummyImplTest extends AbstractCommonsRDFTest {
+public class DummyRDFTermFactoryTest extends AbstractRDFTermFactoryTest {
 
 	@Override
 	public RDFTermFactory createFactory() {

--- a/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactoryTest.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/DummyRDFTermFactoryTest.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.dummyimpl;
 
 import com.github.commonsrdf.api.AbstractRDFTermFactoryTest;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -18,7 +18,7 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public void add(Triple triple) {
-		if (triple == null) { 
+		if (triple == null) {
 			throw new NullPointerException("triple can't be null");
 		}
 		triples.add(triple);
@@ -32,7 +32,7 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public boolean contains(Triple triple) {
-		if (triple == null) { 
+		if (triple == null) {
 			throw new NullPointerException("triple can't be null");
 		}
 		return triples.contains(triple);
@@ -46,15 +46,16 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public void remove(Triple triple) {
-		if (triple == null) { 
+		if (triple == null) {
 			throw new NullPointerException("triple can't be null");
 		}
 		triples.remove(triple);
 	}
 
 	@Override
-	public void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {	
-		Iterator<? extends Triple> it = getTriples(subject, predicate, object).iterator();	
+	public void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		Iterator<? extends Triple> it = getTriples(subject, predicate, object)
+				.iterator();
 		while (it.hasNext()) {
 			it.remove();
 		}
@@ -66,7 +67,7 @@ public class GraphImpl implements Graph {
 	}
 
 	@Override
-	public long size() {		
+	public long size() {
 		return triples.size();
 	}
 
@@ -95,11 +96,11 @@ public class GraphImpl implements Graph {
 		};
 		return getTriples().filter(match);
 	}
-	
+
 	@Override
 	public String toString() {
 		// thread-safe StringBuffer as forEach use parallel streams
-		final StringBuffer sb = new StringBuffer();		
+		final StringBuffer sb = new StringBuffer();
 		getTriples().parallel().forEach(t -> sb.append(t.toString() + "\n"));
 		return sb.toString();
 	}

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -1,8 +1,8 @@
 package com.github.commonsrdf.dummyimpl;
 
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -14,7 +14,7 @@ import com.github.commonsrdf.api.Triple;
 
 public class GraphImpl implements Graph {
 
-	protected Set<Triple> triples = new LinkedHashSet<Triple>();
+	protected List<Triple> triples = new ArrayList<Triple>();
 
 	@Override
 	public void add(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
@@ -60,13 +60,21 @@ public class GraphImpl implements Graph {
 		Predicate<Triple> match = new Predicate<Triple>() {
 			@Override
 			public boolean test(Triple t) {
-				if (subject != null && !t.getSubject().equals(subject)) {
+				// Lacking the requirement for .equals() we have to be silly
+				// and test ntriples string equivalance
+				if (subject != null
+						&& !t.getSubject().ntriplesString()
+								.equals(subject.ntriplesString())) {
 					return false;
 				}
-				if (predicate != null && !t.getPredicate().equals(predicate)) {
+				if (predicate != null
+						&& !t.getPredicate().ntriplesString()
+								.equals(predicate.ntriplesString())) {
 					return false;
 				}
-				if (object != null && !t.getObject().equals(object)) {
+				if (object != null
+						&& !t.getObject().ntriplesString()
+								.equals(object.ntriplesString())) {
 					return false;
 				}
 				return true;
@@ -99,9 +107,8 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public String toString() {
-		// thread-safe StringBuffer as forEach use parallel streams
-		final StringBuffer sb = new StringBuffer();
-		getTriples().parallel().forEach(t -> sb.append(t.toString() + "\n"));
+		final StringBuilder sb = new StringBuilder();
+		getTriples().sequential().forEach(t -> sb.append(t));
 		return sb.toString();
 	}
 

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.dummyimpl;
 
 import java.util.ArrayList;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -15,6 +15,7 @@ import com.github.commonsrdf.api.Triple;
 
 public class GraphImpl implements Graph {
 
+	private static final int TO_STRING_MAX = 10;
 	protected List<Triple> triples = new ArrayList<Triple>();
 
 	@Override
@@ -108,7 +109,13 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public String toString() {
-		return getTriples().map(Object::toString).collect(Collectors.joining("\n"));		
+		String s = getTriples().limit(TO_STRING_MAX).map(Object::toString)
+				.collect(Collectors.joining("\n"));
+		if (size() > TO_STRING_MAX) {
+			return s + "\n# ... +" + (size() - TO_STRING_MAX) + " more";
+		} else {
+			return s;
+		}
 	}
 
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -65,12 +65,12 @@ public class GraphImpl implements Graph {
 	}
 
 	@Override
-	public Stream<? extends Triple> getTriples() {
+	public Stream<Triple> getTriples() {
 		return triples.parallelStream();
 	}
 
 	@Override
-	public Stream<? extends Triple> getTriples(final BlankNodeOrIRI subject,
+	public Stream<Triple> getTriples(final BlankNodeOrIRI subject,
 			final IRI predicate, final RDFTerm object) {
 		Predicate<Triple> match = new Predicate<Triple>() {
 			@Override
@@ -100,8 +100,8 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		for (Triple t : 
-			getTriples(subject, predicate, object).collect(Collectors.toList())) {
+		Stream<? extends Triple> toRemove = getTriples(subject, predicate, object);
+		for (Triple t : toRemove.collect(Collectors.toList())) {
 			// Avoid ConcurrentModificationException in ArrayList
 			remove(t);
 		}

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -100,7 +100,7 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		Stream<? extends Triple> toRemove = getTriples(subject, predicate, object);
+		Stream<Triple> toRemove = getTriples(subject, predicate, object);
 		for (Triple t : toRemove.collect(Collectors.toList())) {
 			// Avoid ConcurrentModificationException in ArrayList
 			remove(t);

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -34,16 +34,16 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public void add(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		add(new TripleImpl(Objects.requireNonNull(subject), 
-				Objects.requireNonNull(predicate), 
+		add(new TripleImpl(Objects.requireNonNull(subject),
+				Objects.requireNonNull(predicate),
 				Objects.requireNonNull(object)));
 
 	}
 
 	@Override
 	public void add(Triple triple) {
-		triples.add(new TripleImpl(Optional.of(this), 
-				Objects.requireNonNull(triple)));
+		triples.add(new TripleImpl(Optional.of(this), Objects
+				.requireNonNull(triple)));
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -14,7 +14,6 @@
 package com.github.commonsrdf.dummyimpl;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.github.commonsrdf.api.BlankNode;
 import com.github.commonsrdf.api.BlankNodeOrIRI;
 import com.github.commonsrdf.api.Graph;
 import com.github.commonsrdf.api.IRI;
@@ -40,6 +41,10 @@ public class GraphImpl implements Graph {
 	public void add(Triple triple) {
 		if (triple == null) {
 			throw new NullPointerException("triple can't be null");
+		}
+		if (triple.getSubject() instanceof BlankNode || triple.getObject() instanceof BlankNode) {
+			// Clone it
+			triple = new TripleImpl(this, triple);
 		}
 		triples.add(triple);
 	}

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -13,8 +13,8 @@
  */
 package com.github.commonsrdf.dummyimpl;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,7 +29,7 @@ import com.github.commonsrdf.api.Triple;
 public class GraphImpl implements Graph {
 
 	private static final int TO_STRING_MAX = 10;
-	protected List<Triple> triples = new ArrayList<Triple>();
+	protected Set<Triple> triples = new LinkedHashSet<Triple>();
 
 	@Override
 	public void add(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -17,6 +17,12 @@ public class GraphImpl implements Graph {
 	protected Set<Triple> triples = new LinkedHashSet<Triple>();
 
 	@Override
+	public void add(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		add(new TripleImpl(subject, predicate, object));
+
+	}
+
+	@Override
 	public void add(Triple triple) {
 		if (triple == null) {
 			throw new NullPointerException("triple can't be null");
@@ -25,17 +31,8 @@ public class GraphImpl implements Graph {
 	}
 
 	@Override
-	public void add(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		add(new TripleImpl(subject, predicate, object));
-
-	}
-
-	@Override
-	public boolean contains(Triple triple) {
-		if (triple == null) {
-			throw new NullPointerException("triple can't be null");
-		}
-		return triples.contains(triple);
+	public void clear() {
+		triples.clear();
 	}
 
 	@Override
@@ -45,30 +42,11 @@ public class GraphImpl implements Graph {
 	}
 
 	@Override
-	public void remove(Triple triple) {
+	public boolean contains(Triple triple) {
 		if (triple == null) {
 			throw new NullPointerException("triple can't be null");
 		}
-		triples.remove(triple);
-	}
-
-	@Override
-	public void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		Iterator<? extends Triple> it = getTriples(subject, predicate, object)
-				.iterator();
-		while (it.hasNext()) {
-			it.remove();
-		}
-	}
-
-	@Override
-	public void clear() {
-		triples.clear();
-	}
-
-	@Override
-	public long size() {
-		return triples.size();
+		return triples.contains(triple);
 	}
 
 	@Override
@@ -95,6 +73,28 @@ public class GraphImpl implements Graph {
 			}
 		};
 		return getTriples().filter(match);
+	}
+
+	@Override
+	public void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		Iterator<? extends Triple> it = getTriples(subject, predicate, object)
+				.iterator();
+		while (it.hasNext()) {
+			it.remove();
+		}
+	}
+
+	@Override
+	public void remove(Triple triple) {
+		if (triple == null) {
+			throw new NullPointerException("triple can't be null");
+		}
+		triples.remove(triple);
+	}
+
+	@Override
+	public long size() {
+		return triples.size();
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -80,7 +80,7 @@ public class GraphImpl implements Graph {
 				return true;
 			}
 		};
-		return getTriples().filter(match);
+		return getTriples().unordered().filter(match);
 	}
 
 	@Override
@@ -108,7 +108,7 @@ public class GraphImpl implements Graph {
 	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder();
-		getTriples().sequential().forEach(t -> sb.append(t));
+		getTriples().sequential().forEach(t -> sb.append(t + "\n"));
 		return sb.toString();
 	}
 

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -14,12 +14,13 @@
 package com.github.commonsrdf.dummyimpl;
 
 import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.github.commonsrdf.api.BlankNode;
 import com.github.commonsrdf.api.BlankNodeOrIRI;
 import com.github.commonsrdf.api.Graph;
 import com.github.commonsrdf.api.IRI;
@@ -33,16 +34,16 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public void add(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		add(new TripleImpl(subject, predicate, object));
+		add(new TripleImpl(Objects.requireNonNull(subject), 
+				Objects.requireNonNull(predicate), 
+				Objects.requireNonNull(object)));
 
 	}
 
 	@Override
 	public void add(Triple triple) {
-		if (triple == null) {
-			throw new NullPointerException("triple can't be null");
-		}
-		triples.add(new TripleImpl(this, triple));
+		triples.add(new TripleImpl(Optional.of(this), 
+				Objects.requireNonNull(triple)));
 	}
 
 	@Override
@@ -58,10 +59,7 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public boolean contains(Triple triple) {
-		if (triple == null) {
-			throw new NullPointerException("triple can't be null");
-		}
-		return triples.contains(triple);
+		return triples.contains(Objects.requireNonNull(triple));
 	}
 
 	@Override
@@ -109,10 +107,7 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public void remove(Triple triple) {
-		if (triple == null) {
-			throw new NullPointerException("triple can't be null");
-		}
-		triples.remove(triple);
+		triples.remove(Objects.requireNonNull(triple));
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -42,11 +42,7 @@ public class GraphImpl implements Graph {
 		if (triple == null) {
 			throw new NullPointerException("triple can't be null");
 		}
-		if (triple.getSubject() instanceof BlankNode || triple.getObject() instanceof BlankNode) {
-			// Clone it
-			triple = new TripleImpl(this, triple);
-		}
-		triples.add(triple);
+		triples.add(new TripleImpl(this, triple));
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/GraphImpl.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.github.commonsrdf.api.BlankNodeOrIRI;
@@ -85,10 +86,10 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public void remove(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		Iterator<? extends Triple> it = getTriples(subject, predicate, object)
-				.iterator();
-		while (it.hasNext()) {
-			it.remove();
+		for (Triple t : 
+			getTriples(subject, predicate, object).collect(Collectors.toList())) {
+			// Avoid ConcurrentModificationException in ArrayList
+			remove(t);
 		}
 	}
 
@@ -107,9 +108,7 @@ public class GraphImpl implements Graph {
 
 	@Override
 	public String toString() {
-		final StringBuilder sb = new StringBuilder();
-		getTriples().sequential().forEach(t -> sb.append(t + "\n"));
-		return sb.toString();
+		return getTriples().map(Object::toString).collect(Collectors.joining("\n"));		
 	}
 
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
@@ -40,5 +40,19 @@ public class IRIImpl implements IRI {
 	public String toString() {
 		return ntriplesString();
 	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (! (obj instanceof IRI)) { 
+			return false;
+		}
+		IRI other = (IRI) obj;
+		return getIRIString().equals(other.getIRIString());
+	}
 
+	@Override
+	public int hashCode() {		
+		return getIRIString().hashCode();
+	}
+	
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
@@ -14,13 +14,13 @@ public class IRIImpl implements IRI {
 	}
 
 	@Override
-	public String ntriplesString() {
-		return "<" + getIRIString() + ">";
+	public String getIRIString() {
+		return uri.toString();
 	}
 
 	@Override
-	public String getIRIString() {
-		return uri.toString();
+	public String ntriplesString() {
+		return "<" + getIRIString() + ">";
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.dummyimpl;
 
 import java.net.URI;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
@@ -24,7 +24,7 @@ public class IRIImpl implements IRI {
 	public IRIImpl(String iri) {
 		// TODO: Check against http://www.w3.org/TR/n-triples/#n-triples-grammar
 		// FIXME: URI.create uses outdated RFC2396 and will get some IDNs wrong
-		// should throw IllegalArgumentException on most illegal IRIs 
+		// should throw IllegalArgumentException on most illegal IRIs
 		uri = URI.create(iri);
 	}
 
@@ -42,10 +42,10 @@ public class IRIImpl implements IRI {
 	public String toString() {
 		return ntriplesString();
 	}
-	
+
 	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof IRI)) { 
+		if (!(obj instanceof IRI)) {
 			return false;
 		}
 		IRI other = (IRI) obj;
@@ -53,8 +53,8 @@ public class IRIImpl implements IRI {
 	}
 
 	@Override
-	public int hashCode() {		
+	public int hashCode() {
 		return uri.hashCode();
 	}
-	
+
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
@@ -54,7 +54,7 @@ public class IRIImpl implements IRI {
 
 	@Override
 	public int hashCode() {		
-		return getIRIString().hashCode();
+		return uri.hashCode();
 	}
 	
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
@@ -23,6 +23,8 @@ public class IRIImpl implements IRI {
 
 	public IRIImpl(String iri) {
 		// TODO: Check against http://www.w3.org/TR/n-triples/#n-triples-grammar
+		// FIXME: URI.create uses outdated RFC2396 and will get some IDNs wrong
+		// should throw IllegalArgumentException on most illegal IRIs 
 		uri = URI.create(iri);
 	}
 

--- a/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/IRIImpl.java
@@ -7,12 +7,12 @@ import com.github.commonsrdf.api.IRI;
 public class IRIImpl implements IRI {
 
 	protected URI uri;
-	
-	public IRIImpl(String iri) {		
+
+	public IRIImpl(String iri) {
 		// TODO: Check against http://www.w3.org/TR/n-triples/#n-triples-grammar
 		uri = URI.create(iri);
 	}
-	
+
 	@Override
 	public String ntriplesString() {
 		return "<" + getIRIString() + ">";
@@ -22,7 +22,7 @@ public class IRIImpl implements IRI {
 	public String getIRIString() {
 		return uri.toString();
 	}
-	
+
 	@Override
 	public String toString() {
 		return ntriplesString();

--- a/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
@@ -108,12 +108,7 @@ public class LiteralImpl implements Literal {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + dataType.hashCode();
-		result = prime * result + lexicalForm.hashCode();
-		result = prime * result + languageTag.hashCode();
-		return result;
+		return Objects.hash(dataType, lexicalForm, languageTag);
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
@@ -7,42 +7,45 @@ import com.github.commonsrdf.api.Literal;
 
 public class LiteralImpl implements Literal {
 
-	private static final IRIImpl XSD_STRING = new IRIImpl("http://www.w3.org/2001/XMLSchema#string");
-	private static final IRIImpl RDF_LANG_STRING = new IRIImpl("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString");
+	private static final IRIImpl XSD_STRING = new IRIImpl(
+			"http://www.w3.org/2001/XMLSchema#string");
+	private static final IRIImpl RDF_LANG_STRING = new IRIImpl(
+			"http://www.w3.org/1999/02/22-rdf-syntax-ns#langString");
 	private static final String QUOTE = "\"";
 
 	private Optional<String> languageTag;
 	private IRI dataType;
 	private String lexicalForm;
-	
+
 	public LiteralImpl(String literal) {
-		if (literal == null) { 
+		if (literal == null) {
 			throw new NullPointerException("literal can't be null");
 		}
 		this.lexicalForm = literal;
 		this.dataType = XSD_STRING;
 		this.languageTag = Optional.empty();
 	}
-	
+
 	public LiteralImpl(String literal, String languageTag) {
-		if (literal == null) { 
+		if (literal == null) {
 			throw new NullPointerException("literal can't be null");
 		}
 		this.lexicalForm = literal;
 		this.languageTag = Optional.of(languageTag);
-		if (languageTag.isEmpty()) { 
-			// TODO: Check against http://www.w3.org/TR/n-triples/#n-triples-grammar
+		if (languageTag.isEmpty()) {
+			// TODO: Check against
+			// http://www.w3.org/TR/n-triples/#n-triples-grammar
 			throw new IllegalArgumentException("Language tag can't be null");
 		}
-		this.dataType = RDF_LANG_STRING;		
+		this.dataType = RDF_LANG_STRING;
 	}
-	
+
 	public LiteralImpl(String lexicalForm, IRI dataType) {
-		if (lexicalForm == null) { 
+		if (lexicalForm == null) {
 			throw new NullPointerException("lexicalForm can't be null");
 		}
-		this.lexicalForm = lexicalForm;		
-		if (dataType == null) { 
+		this.lexicalForm = lexicalForm;
+		if (dataType == null) {
 			throw new NullPointerException("dataType can't be null");
 		}
 		this.dataType = dataType;
@@ -54,22 +57,22 @@ public class LiteralImpl implements Literal {
 		StringBuilder sb = new StringBuilder();
 		sb.append(QUOTE);
 		// Escape special characters
-		sb.append(getLexicalForm().
-				replace("\\", "\\\\").  // escaped to \\
-				replace("\"", "\\\"").  // escaped to \"
-				replace("\r", "\\r").   // escaped to \r
-				replace("\n", "\\n"));  // escaped to \n
+		sb.append(getLexicalForm().replace("\\", "\\\\"). // escaped to \\
+				replace("\"", "\\\""). // escaped to \"
+				replace("\r", "\\r"). // escaped to \r
+				replace("\n", "\\n")); // escaped to \n
 		sb.append(QUOTE);
 
-		//getLanguageTag().ifPresent(s -> sb.append("@" + s));
+		// getLanguageTag().ifPresent(s -> sb.append("@" + s));
 		if (getLanguageTag().isPresent()) {
 			sb.append("@");
 			sb.append(getLanguageTag().get());
-		
-		} else if (! getDatatype().getIRIString().equals(XSD_STRING.getIRIString())) { 
+
+		} else if (!getDatatype().getIRIString().equals(
+				XSD_STRING.getIRIString())) {
 			sb.append("^^");
 			sb.append(getDatatype().ntriplesString());
-		}		
+		}
 		return sb.toString();
 	}
 
@@ -79,7 +82,7 @@ public class LiteralImpl implements Literal {
 	}
 
 	@Override
-	public IRI getDatatype() {		
+	public IRI getDatatype() {
 		return dataType;
 	}
 
@@ -87,7 +90,7 @@ public class LiteralImpl implements Literal {
 	public Optional<String> getLanguageTag() {
 		return languageTag;
 	}
-	
+
 	@Override
 	public String toString() {
 		return ntriplesString();

--- a/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
@@ -69,8 +69,7 @@ public class LiteralImpl implements Literal {
 		} else if (! getDatatype().getIRIString().equals(XSD_STRING.getIRIString())) { 
 			sb.append("^^");
 			sb.append(getDatatype().ntriplesString());
-		}
-		sb.append(QUOTE);
+		}		
 		return sb.toString();
 	}
 

--- a/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.dummyimpl;
 
 import java.util.Optional;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
@@ -56,10 +56,11 @@ public class LiteralImpl implements Literal {
 		try {
 			new Locale.Builder().setLanguageTag(languageTag);
 		} catch (IllformedLocaleException ex) {
-			throw new IllegalArgumentException("Invalid languageTag: " + languageTag, ex);
+			throw new IllegalArgumentException("Invalid languageTag: "
+					+ languageTag, ex);
 		}
-		
-		//System.out.println(aLocale);
+
+		// System.out.println(aLocale);
 		this.dataType = RDF_LANG_STRING;
 	}
 
@@ -113,14 +114,13 @@ public class LiteralImpl implements Literal {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof Literal)) {
+		if (!(obj instanceof Literal)) {
 			return false;
 		}
-		Literal literal = (Literal) obj;		
-		return  getDatatype().equals(literal.getDatatype()) && 
-				getLexicalForm().equals(literal.getLexicalForm()) && 
-				getLanguageTag().equals(literal.getLanguageTag());
+		Literal literal = (Literal) obj;
+		return getDatatype().equals(literal.getDatatype())
+				&& getLexicalForm().equals(literal.getLexicalForm())
+				&& getLanguageTag().equals(literal.getLanguageTag());
 	}
-	
-	
+
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
@@ -7,14 +7,14 @@ import com.github.commonsrdf.api.Literal;
 
 public class LiteralImpl implements Literal {
 
-	private static final IRIImpl XSD_STRING = new IRIImpl(
-			"http://www.w3.org/2001/XMLSchema#string");
+	private static final String QUOTE = "\"";
 	private static final IRIImpl RDF_LANG_STRING = new IRIImpl(
 			"http://www.w3.org/1999/02/22-rdf-syntax-ns#langString");
-	private static final String QUOTE = "\"";
+	private static final IRIImpl XSD_STRING = new IRIImpl(
+			"http://www.w3.org/2001/XMLSchema#string");
 
-	private Optional<String> languageTag;
 	private IRI dataType;
+	private Optional<String> languageTag;
 	private String lexicalForm;
 
 	public LiteralImpl(String literal) {
@@ -23,6 +23,18 @@ public class LiteralImpl implements Literal {
 		}
 		this.lexicalForm = literal;
 		this.dataType = XSD_STRING;
+		this.languageTag = Optional.empty();
+	}
+
+	public LiteralImpl(String lexicalForm, IRI dataType) {
+		if (lexicalForm == null) {
+			throw new NullPointerException("lexicalForm can't be null");
+		}
+		this.lexicalForm = lexicalForm;
+		if (dataType == null) {
+			throw new NullPointerException("dataType can't be null");
+		}
+		this.dataType = dataType;
 		this.languageTag = Optional.empty();
 	}
 
@@ -40,16 +52,19 @@ public class LiteralImpl implements Literal {
 		this.dataType = RDF_LANG_STRING;
 	}
 
-	public LiteralImpl(String lexicalForm, IRI dataType) {
-		if (lexicalForm == null) {
-			throw new NullPointerException("lexicalForm can't be null");
-		}
-		this.lexicalForm = lexicalForm;
-		if (dataType == null) {
-			throw new NullPointerException("dataType can't be null");
-		}
-		this.dataType = dataType;
-		this.languageTag = Optional.empty();
+	@Override
+	public IRI getDatatype() {
+		return dataType;
+	}
+
+	@Override
+	public Optional<String> getLanguageTag() {
+		return languageTag;
+	}
+
+	@Override
+	public String getLexicalForm() {
+		return lexicalForm;
 	}
 
 	@Override
@@ -74,21 +89,6 @@ public class LiteralImpl implements Literal {
 			sb.append(getDatatype().ntriplesString());
 		}
 		return sb.toString();
-	}
-
-	@Override
-	public String getLexicalForm() {
-		return lexicalForm;
-	}
-
-	@Override
-	public IRI getDatatype() {
-		return dataType;
-	}
-
-	@Override
-	public Optional<String> getLanguageTag() {
-		return languageTag;
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
@@ -96,8 +96,7 @@ public class LiteralImpl implements Literal {
 			sb.append("@");
 			sb.append(getLanguageTag().get());
 
-		} else if (!getDatatype().getIRIString().equals(
-				XSD_STRING.getIRIString())) {
+		} else if (!getDatatype().equals(XSD_STRING)) {
 			sb.append("^^");
 			sb.append(getDatatype().ntriplesString());
 		}
@@ -109,4 +108,29 @@ public class LiteralImpl implements Literal {
 		return ntriplesString();
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result
+				+ ((dataType == null) ? 0 : dataType.hashCode());
+		result = prime * result
+				+ ((lexicalForm == null) ? 0 : lexicalForm.hashCode());
+		result = prime * result
+				+ ((languageTag == null) ? 0 : languageTag.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (! (obj instanceof Literal)) {
+			return false;
+		}
+		Literal literal = (Literal) obj;		
+		return  getDatatype().equals(literal.getDatatype()) && 
+				getLexicalForm().equals(literal.getLexicalForm()) && 
+				getLanguageTag().equals(literal.getLanguageTag());
+	}
+	
+	
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
@@ -15,6 +15,7 @@ package com.github.commonsrdf.dummyimpl;
 
 import java.util.IllformedLocaleException;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.github.commonsrdf.api.IRI;
@@ -33,31 +34,19 @@ public class LiteralImpl implements Literal {
 	private String lexicalForm;
 
 	public LiteralImpl(String literal) {
-		if (literal == null) {
-			throw new NullPointerException("literal can't be null");
-		}
-		this.lexicalForm = literal;
+		this.lexicalForm = Objects.requireNonNull(literal);
 		this.dataType = XSD_STRING;
 		this.languageTag = Optional.empty();
 	}
 
 	public LiteralImpl(String lexicalForm, IRI dataType) {
-		if (lexicalForm == null) {
-			throw new NullPointerException("lexicalForm can't be null");
-		}
-		this.lexicalForm = lexicalForm;
-		if (dataType == null) {
-			throw new NullPointerException("dataType can't be null");
-		}
-		this.dataType = dataType;
+		this.lexicalForm = Objects.requireNonNull(lexicalForm);
+		this.dataType = Objects.requireNonNull(dataType);
 		this.languageTag = Optional.empty();
 	}
 
 	public LiteralImpl(String literal, String languageTag) {
-		if (literal == null) {
-			throw new NullPointerException("literal can't be null");
-		}
-		this.lexicalForm = literal;
+		this.lexicalForm = Objects.requireNonNull(literal);
 		this.languageTag = Optional.of(languageTag);
 		if (languageTag.isEmpty()) {
 			// TODO: Check against
@@ -121,12 +110,9 @@ public class LiteralImpl implements Literal {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result
-				+ ((dataType == null) ? 0 : dataType.hashCode());
-		result = prime * result
-				+ ((lexicalForm == null) ? 0 : lexicalForm.hashCode());
-		result = prime * result
-				+ ((languageTag == null) ? 0 : languageTag.hashCode());
+		result = prime * result + dataType.hashCode();
+		result = prime * result + lexicalForm.hashCode();
+		result = prime * result + languageTag.hashCode();
 		return result;
 	}
 

--- a/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/LiteralImpl.java
@@ -13,6 +13,8 @@
  */
 package com.github.commonsrdf.dummyimpl;
 
+import java.util.IllformedLocaleException;
+import java.util.Locale;
 import java.util.Optional;
 
 import com.github.commonsrdf.api.IRI;
@@ -62,6 +64,13 @@ public class LiteralImpl implements Literal {
 			// http://www.w3.org/TR/n-triples/#n-triples-grammar
 			throw new IllegalArgumentException("Language tag can't be null");
 		}
+		try {
+			new Locale.Builder().setLanguageTag(languageTag);
+		} catch (IllformedLocaleException ex) {
+			throw new IllegalArgumentException("Invalid languageTag: " + languageTag, ex);
+		}
+		
+		//System.out.println(aLocale);
 		this.dataType = RDF_LANG_STRING;
 	}
 

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
@@ -26,6 +26,9 @@ import com.github.commonsrdf.api.IRI;
 
 public class TestWritingGraph {
 
+	/** Run tests with -Dkeepfiles=true to inspect /tmp files **/
+	private static boolean KEEP_FILES = Boolean.getBoolean("keepfiles");
+
 	private GraphImpl graph;
 
 	@Before
@@ -34,36 +37,40 @@ public class TestWritingGraph {
 		BlankNode subject = new BlankNodeImpl("subj");
 		IRI predicate = new IRIImpl("pred");
 		// 200k triples should do
-		for (int i=0; i<200000; i++) {
-			graph.add(subject, predicate, 
-					new LiteralImpl("Example " + i, "en"));		
-		}		
+		for (int i = 0; i < 200000; i++) {
+			graph.add(subject, predicate, new LiteralImpl("Example " + i, "en"));
+		}
 	}
-	
+
 	@Test
 	public void writeGraphFromStream() throws Exception {
 		Path graphFile = Files.createTempFile("graph", ".nt");
-		System.out.println("From stream: " + graphFile);		
-		Stream<CharSequence> stream = graph.getTriples().unordered().parallel().
-				map(Object::toString);
-		Files.write(graphFile, 
-				stream::iterator,
-				Charset.forName("UTF-8"));
+		if (KEEP_FILES) {
+			System.out.println("From stream: " + graphFile);
+		} else {
+			graphFile.toFile().deleteOnExit();
+		}
+
+		Stream<CharSequence> stream = graph.getTriples().unordered().parallel()
+				.map(Object::toString);
+		Files.write(graphFile, stream::iterator, Charset.forName("UTF-8"));
 	}
 
 	@Test
 	public void writeGraphFromStreamFiltered() throws Exception {
-		Path graphFile = Files.createTempFile("graph", ".nt");		
-		System.out.println("Filtered stream: " + graphFile);
-		BlankNode subject = new BlankNodeImpl("subj"); 
-		IRI predicate = new IRIImpl("pred");
-		Stream<CharSequence> stream = graph.getTriples(subject, predicate, null).
-				map(Object::toString);
-		Files.write(graphFile, 
-				stream::iterator,
-				Charset.forName("UTF-8"));
+		Path graphFile = Files.createTempFile("graph", ".nt");
+		if (KEEP_FILES) {
+			System.out.println("Filtered stream: " + graphFile);
+		} else {
+			graphFile.toFile().deleteOnExit();
+		}
 		
+		BlankNode subject = new BlankNodeImpl("subj");
+		IRI predicate = new IRIImpl("pred");
+		Stream<CharSequence> stream = graph
+				.getTriples(subject, predicate, null).map(Object::toString);
+		Files.write(graphFile, stream::iterator, Charset.forName("UTF-8"));
+
 	}
 
 }
- 

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
@@ -32,7 +32,7 @@ public class TestWritingGraph {
 		Path graphFile = Files.createTempFile("graph", ".nt");
 		System.out.println("From stream: " + graphFile);		
 		Stream<CharSequence> stream = graph.getTriples().unordered().parallel().
-				map(t -> t.toString());
+				map(Object::toString);
 		Files.write(graphFile, 
 				stream::iterator,
 				Charset.forName("UTF-8"));
@@ -45,7 +45,7 @@ public class TestWritingGraph {
 		BlankNode subject = new BlankNodeImpl("subj"); 
 		IRI predicate = new IRIImpl("pred");
 		Stream<CharSequence> stream = graph.getTriples(subject, predicate, null).
-				map(t -> t.toString());
+				map(Object::toString);
 		Files.write(graphFile, 
 				stream::iterator,
 				Charset.forName("UTF-8"));

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
@@ -16,6 +16,7 @@ package com.github.commonsrdf.dummyimpl;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.Before;
@@ -34,7 +35,7 @@ public class TestWritingGraph {
 	@Before
 	public void createGraph() throws Exception {
 		graph = new GraphImpl();
-		BlankNode subject = new BlankNodeImpl(graph, "subj");
+		BlankNode subject = new BlankNodeImpl(Optional.of(graph), "subj");
 		IRI predicate = new IRIImpl("pred");
 		// 200k triples should do
 		for (int i = 0; i < 200000; i++) {
@@ -65,7 +66,7 @@ public class TestWritingGraph {
 			graphFile.toFile().deleteOnExit();
 		}
 
-		BlankNode subject = new BlankNodeImpl(graph, "subj");
+		BlankNode subject = new BlankNodeImpl(Optional.of(graph), "subj");
 		IRI predicate = new IRIImpl("pred");
 		Stream<CharSequence> stream = graph
 				.getTriples(subject, predicate, null).map(Object::toString);

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
@@ -1,0 +1,56 @@
+package com.github.commonsrdf.dummyimpl;
+
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.commonsrdf.api.BlankNode;
+import com.github.commonsrdf.api.IRI;
+
+public class TestWritingGraph {
+
+	private GraphImpl graph;
+
+	@Before
+	public void createGraph() throws Exception {
+		graph = new GraphImpl();
+		BlankNode subject = new BlankNodeImpl("subj");
+		IRI predicate = new IRIImpl("pred");
+		// 200k triples should do
+		for (int i=0; i<200000; i++) {
+			graph.add(subject, predicate, 
+					new LiteralImpl("Example " + i, "en"));		
+		}		
+	}
+	
+	@Test
+	public void writeGraphFromStream() throws Exception {
+		Path graphFile = Files.createTempFile("graph", ".nt");
+		System.out.println("From stream: " + graphFile);		
+		Stream<CharSequence> stream = graph.getTriples().unordered().parallel().
+				map(t -> t.toString());
+		Files.write(graphFile, 
+				stream::iterator,
+				Charset.forName("UTF-8"));
+	}
+
+	@Test
+	public void writeGraphFromStreamFiltered() throws Exception {
+		Path graphFile = Files.createTempFile("graph", ".nt");		
+		System.out.println("Filtered stream: " + graphFile);
+		BlankNode subject = new BlankNodeImpl("subj"); 
+		IRI predicate = new IRIImpl("pred");
+		Stream<CharSequence> stream = graph.getTriples(subject, predicate, null).
+				map(t -> t.toString());
+		Files.write(graphFile, 
+				stream::iterator,
+				Charset.forName("UTF-8"));
+		
+	}
+
+}
+ 

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
@@ -64,7 +64,7 @@ public class TestWritingGraph {
 		} else {
 			graphFile.toFile().deleteOnExit();
 		}
-		
+
 		BlankNode subject = new BlankNodeImpl("subj");
 		IRI predicate = new IRIImpl("pred");
 		Stream<CharSequence> stream = graph

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.dummyimpl;
 
 import java.nio.charset.Charset;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TestWritingGraph.java
@@ -34,7 +34,7 @@ public class TestWritingGraph {
 	@Before
 	public void createGraph() throws Exception {
 		graph = new GraphImpl();
-		BlankNode subject = new BlankNodeImpl("subj");
+		BlankNode subject = new BlankNodeImpl(graph, "subj");
 		IRI predicate = new IRIImpl("pred");
 		// 200k triples should do
 		for (int i = 0; i < 200000; i++) {
@@ -65,7 +65,7 @@ public class TestWritingGraph {
 			graphFile.toFile().deleteOnExit();
 		}
 
-		BlankNode subject = new BlankNodeImpl("subj");
+		BlankNode subject = new BlankNodeImpl(graph, "subj");
 		IRI predicate = new IRIImpl("pred");
 		Stream<CharSequence> stream = graph
 				.getTriples(subject, predicate, null).map(Object::toString);

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -42,7 +42,7 @@ public class TripleImpl implements Triple {
 	public TripleImpl(Graph localScope, Triple triple) {
 		this.subject = (BlankNodeOrIRI)inScope(localScope, triple.getSubject());
 		this.predicate = (IRI)inScope(localScope, triple.getPredicate());
-		this.object = inScope(localScope, triple.getPredicate());
+		this.object = inScope(localScope, triple.getObject());
 	}
 
 	private RDFTerm inScope(Graph localScope, RDFTerm object) {

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -31,12 +31,9 @@ public class TripleImpl implements Triple {
 	private RDFTerm object;
 
 	public TripleImpl(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		if (subject == null || predicate == null || object == null) {
-			throw new NullPointerException("subject, predicate or object was null");
-		}
-		this.subject = (BlankNodeOrIRI) inScope(null, subject);
-		this.predicate = (IRI) inScope(null, predicate);
-		this.object = inScope(null, object);
+		this.subject = (BlankNodeOrIRI) inScope(Optional.empty(), Objects.requireNonNull(subject));
+		this.predicate = (IRI) inScope(null, Objects.requireNonNull(predicate));
+		this.object = inScope(Optional.empty(), Objects.requireNonNull(object));
 	}
 
 	/** Construct Triple by cloning another Triple and its constituent parts

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -7,9 +7,9 @@ import com.github.commonsrdf.api.Triple;
 
 public class TripleImpl implements Triple {
 
-	private BlankNodeOrIRI subject;
-	private IRI predicate;
 	private RDFTerm object;
+	private IRI predicate;
+	private BlankNodeOrIRI subject;
 
 	public TripleImpl(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
 		this.subject = subject;
@@ -18,8 +18,8 @@ public class TripleImpl implements Triple {
 	}
 
 	@Override
-	public BlankNodeOrIRI getSubject() {
-		return subject;
+	public RDFTerm getObject() {
+		return object;
 	}
 
 	@Override
@@ -28,8 +28,8 @@ public class TripleImpl implements Triple {
 	}
 
 	@Override
-	public RDFTerm getObject() {
-		return object;
+	public BlankNodeOrIRI getSubject() {
+		return subject;
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -13,7 +13,9 @@
  */
 package com.github.commonsrdf.dummyimpl;
 
+import com.github.commonsrdf.api.BlankNode;
 import com.github.commonsrdf.api.BlankNodeOrIRI;
+import com.github.commonsrdf.api.Graph;
 import com.github.commonsrdf.api.IRI;
 import com.github.commonsrdf.api.RDFTerm;
 import com.github.commonsrdf.api.Triple;
@@ -31,6 +33,24 @@ public class TripleImpl implements Triple {
 		this.subject = subject;
 		this.predicate = predicate;
 		this.object = object;
+	}
+
+	/** Construct Triple by cloning another Triple and its constituent parts
+	 * @param localScope Scope to create new triple in
+	 * @param triple Triple to clone
+	 */
+	public TripleImpl(Graph localScope, Triple triple) {
+		this.subject = (BlankNodeOrIRI)inScope(localScope, triple.getSubject());
+		this.predicate = (IRI)inScope(localScope, triple.getPredicate());
+		this.object = inScope(localScope, triple.getPredicate());
+	}
+
+	private RDFTerm inScope(Graph localScope, RDFTerm object) {
+		if (object instanceof BlankNode) {
+			BlankNode blankNode = (BlankNode) object; 
+			return new BlankNodeImpl(localScope, blankNode.internalIdentifier());
+		}
+		return object;
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -36,6 +36,6 @@ public class TripleImpl implements Triple {
 	public String toString() {
 		return getSubject().ntriplesString() + " "
 				+ getPredicate().ntriplesString() + " "
-				+ getObject().ntriplesString() + ".";
+				+ getObject().ntriplesString() + " .";
 	}
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -25,6 +25,9 @@ public class TripleImpl implements Triple {
 	private RDFTerm object;
 
 	public TripleImpl(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
+		if (subject == null || predicate == null || object == null) {
+			throw new NullPointerException("subject, predicate or object was null");
+		}
 		this.subject = subject;
 		this.predicate = predicate;
 		this.object = object;
@@ -51,4 +54,28 @@ public class TripleImpl implements Triple {
 				+ getPredicate().ntriplesString() + " "
 				+ getObject().ntriplesString() + " .";
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + subject.hashCode();
+		result = prime * result +  predicate.hashCode();
+		result = prime * result + object.hashCode();
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof Triple)) {
+			return false;
+		}
+		Triple other = (Triple) obj;
+		return getSubject().equals(other.getSubject()) &&
+				getPredicate().equals(other.getPredicate()) && 
+				getObject().equals(other.getObject());		
+	}
+	
+	
+	
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -31,40 +31,50 @@ public class TripleImpl implements Triple {
 	private RDFTerm object;
 
 	public TripleImpl(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		this.subject = (BlankNodeOrIRI) inScope(Optional.empty(), Objects.requireNonNull(subject));
+		this.subject = (BlankNodeOrIRI) inScope(Optional.empty(),
+				Objects.requireNonNull(subject));
 		this.predicate = (IRI) inScope(null, Objects.requireNonNull(predicate));
 		this.object = inScope(Optional.empty(), Objects.requireNonNull(object));
 	}
 
-	/** Construct Triple by cloning another Triple and its constituent parts
-	 * @param localScope Scope to create new triple in
-	 * @param triple Triple to clone
+	/**
+	 * Construct Triple by cloning another Triple and its constituent parts
+	 * 
+	 * @param localScope
+	 *            Scope to create new triple in
+	 * @param triple
+	 *            Triple to clone
 	 */
 	public TripleImpl(Optional<Graph> localScope, Triple triple) {
 		Objects.requireNonNull(localScope);
 		Objects.requireNonNull(triple);
-		
-		this.subject = (BlankNodeOrIRI)inScope(localScope, triple.getSubject());
-		this.predicate = (IRI)inScope(localScope, triple.getPredicate());
+
+		this.subject = (BlankNodeOrIRI) inScope(localScope, triple.getSubject());
+		this.predicate = (IRI) inScope(localScope, triple.getPredicate());
 		this.object = inScope(localScope, triple.getObject());
 	}
 
 	private RDFTerm inScope(Optional<Graph> localScope, RDFTerm object) {
-		if (! (object instanceof BlankNode) && ! (object instanceof IRI) & ! (object instanceof Literal)) {
-			throw new IllegalArgumentException("RDFTerm must be BlankNode, IRI or Literal");
+		if (!(object instanceof BlankNode) && !(object instanceof IRI)
+				& !(object instanceof Literal)) {
+			throw new IllegalArgumentException(
+					"RDFTerm must be BlankNode, IRI or Literal");
 		}
 		if (object instanceof BlankNode) {
-			BlankNode blankNode = (BlankNode) object; 
-			return new BlankNodeImpl(Objects.requireNonNull(localScope), blankNode.internalIdentifier());
-		} else if (object instanceof IRI && ! (object instanceof IRIImpl)) {
+			BlankNode blankNode = (BlankNode) object;
+			return new BlankNodeImpl(Objects.requireNonNull(localScope),
+					blankNode.internalIdentifier());
+		} else if (object instanceof IRI && !(object instanceof IRIImpl)) {
 			IRI iri = (IRI) object;
 			return new IRIImpl(iri.getIRIString());
-		} else if (object instanceof Literal && ! (object instanceof LiteralImpl)) {
+		} else if (object instanceof Literal
+				&& !(object instanceof LiteralImpl)) {
 			Literal literal = (Literal) object;
 			if (literal.getLanguageTag().isPresent()) {
-				return new LiteralImpl(literal.getLexicalForm(), literal.getLanguageTag().get());
-			} else { 
-				IRI dataType = (IRI) inScope(localScope, literal.getDatatype());			
+				return new LiteralImpl(literal.getLexicalForm(), literal
+						.getLanguageTag().get());
+			} else {
+				IRI dataType = (IRI) inScope(localScope, literal.getDatatype());
 				return new LiteralImpl(literal.getLexicalForm(), dataType);
 			}
 		} else {
@@ -105,11 +115,9 @@ public class TripleImpl implements Triple {
 			return false;
 		}
 		Triple other = (Triple) obj;
-		return getSubject().equals(other.getSubject()) &&
-				getPredicate().equals(other.getPredicate()) && 
-				getObject().equals(other.getObject());		
+		return getSubject().equals(other.getSubject())
+				&& getPredicate().equals(other.getPredicate())
+				&& getObject().equals(other.getObject());
 	}
-	
-	
-	
+
 }

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -13,6 +13,7 @@
  */
 package com.github.commonsrdf.dummyimpl;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import com.github.commonsrdf.api.BlankNode;
@@ -43,6 +44,9 @@ public class TripleImpl implements Triple {
 	 * @param triple Triple to clone
 	 */
 	public TripleImpl(Optional<Graph> localScope, Triple triple) {
+		Objects.requireNonNull(localScope);
+		Objects.requireNonNull(triple);
+		
 		this.subject = (BlankNodeOrIRI)inScope(localScope, triple.getSubject());
 		this.predicate = (IRI)inScope(localScope, triple.getPredicate());
 		this.object = inScope(localScope, triple.getObject());
@@ -54,7 +58,7 @@ public class TripleImpl implements Triple {
 		}
 		if (object instanceof BlankNode) {
 			BlankNode blankNode = (BlankNode) object; 
-			return new BlankNodeImpl(localScope, blankNode.internalIdentifier());
+			return new BlankNodeImpl(Objects.requireNonNull(localScope), blankNode.internalIdentifier());
 		} else if (object instanceof IRI && ! (object instanceof IRIImpl)) {
 			IRI iri = (IRI) object;
 			return new IRIImpl(iri.getIRIString());
@@ -95,12 +99,7 @@ public class TripleImpl implements Triple {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + subject.hashCode();
-		result = prime * result +  predicate.hashCode();
-		result = prime * result + object.hashCode();
-		return result;
+		return Objects.hash(subject, predicate, object);
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -7,9 +7,9 @@ import com.github.commonsrdf.api.Triple;
 
 public class TripleImpl implements Triple {
 
-	private RDFTerm object;
-	private IRI predicate;
 	private BlankNodeOrIRI subject;
+	private IRI predicate;
+	private RDFTerm object;
 
 	public TripleImpl(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
 		this.subject = subject;
@@ -18,8 +18,8 @@ public class TripleImpl implements Triple {
 	}
 
 	@Override
-	public RDFTerm getObject() {
-		return object;
+	public BlankNodeOrIRI getSubject() {
+		return subject;
 	}
 
 	@Override
@@ -28,8 +28,8 @@ public class TripleImpl implements Triple {
 	}
 
 	@Override
-	public BlankNodeOrIRI getSubject() {
-		return subject;
+	public RDFTerm getObject() {
+		return object;
 	}
 
 	@Override

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.commonsrdf.dummyimpl;
 
 import com.github.commonsrdf.api.BlankNodeOrIRI;

--- a/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
+++ b/src/test/java/com/github/commonsrdf/dummyimpl/TripleImpl.java
@@ -14,7 +14,7 @@ public class TripleImpl implements Triple {
 	public TripleImpl(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
 		this.subject = subject;
 		this.predicate = predicate;
-		this.object = object;	
+		this.object = object;
 	}
 
 	@Override
@@ -31,9 +31,11 @@ public class TripleImpl implements Triple {
 	public RDFTerm getObject() {
 		return object;
 	}
-	
+
 	@Override
 	public String toString() {
-		return getSubject().ntriplesString() + " " + getPredicate().ntriplesString() + " " + getObject().ntriplesString() + ".";
+		return getSubject().ntriplesString() + " "
+				+ getPredicate().ntriplesString() + " "
+				+ getObject().ntriplesString() + ".";
 	}
 }


### PR DESCRIPTION
This mainly is intended to test out if the API makes sense, and to give examples of what it can be used for on its own. I found several ambiguities that I will raise individually.

The dummy implementation is basically just some beans and a java.util.List. This uses the Java 8 Streaming APIs, so I did not attempt to back-patch everything to java6 - the `java6` profile simply ignores the whole of `src/test/java` for now.

The tests are written through two abstract classes, so that they can be reused as-is in a different implementation. The test-jar would probably be needed for that (See #40)

The only thing needed to provide is an instance of the [RDFTermFactory](https://github.com/stain/commons-rdf/blob/tests/src/test/java/com/github/commonsrdf/api/RDFTermFactory.java) - I put this in `src/test/java` for now - although it might be genuinely useful as part of the APIs. (I have not tested how easy it is to plug into this from other implementations).

There's a jewel test in there that you would enjoy if you like SPARQL...