### PR TITLE
Triple.equals and hashCode

### DIFF
--- a/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -14,7 +14,7 @@
 package com.github.commonsrdf.api;
 
 /**
- * An <a href= "http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node" >RDF-1.1
+ * A <a href= "http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node" >RDF-1.1
  * Blank Node</a>, as defined by <a href=
  * "http://www.w3.org/TR/rdf11-concepts/#section-blank-nodes" >RDF-1.1 Concepts
  * and Abstract Syntax</a>, a W3C Recommendation published on 25 February 2014.<br>
@@ -107,7 +107,7 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * @see Object#equals(Object)
 	 * 
 	 * @param other
-	 * @return true if other is an BlankNode, is in the same local scope and is
+	 * @return true if other is a BlankNode, is in the same local scope and is
 	 *         equal to this BlankNode
 	 */
     @Override

--- a/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -76,5 +76,55 @@ public interface BlankNode extends BlankNodeOrIRI {
      * @return An internal, system identifier for the {@link BlankNode}.
      */
     String internalIdentifier();
+    
+
+	/**
+	 * Check it this BlankNode is equal to another BlankNode.
+	 * <p>
+	 * <blockquote cite="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">
+	 * <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">Blank
+	 * node identifiers</a> are local identifiers that are used in some concrete
+	 * RDF syntaxes or RDF store implementations. They are always locally scoped
+	 * to the file or RDF store, and are <em>not</em> persistent or portable
+	 * identifiers for blank nodes. Blank node identifiers are <em>not</em> part
+	 * of the RDF abstract syntax, but are entirely dependent on the concrete
+	 * syntax or implementation. The syntactic restrictions on blank node
+	 * identifiers, if any, therefore also depend on the concrete RDF syntax or
+	 * implementation. Implementations that handle blank node identifiers in
+	 * concrete syntaxes need to be careful not to create the same blank node
+	 * from multiple occurrences of the same blank node identifier except in
+	 * situations where this is supported by the syntax. 
+	 * </blockquote>
+	 * <p>
+	 * Implementations MUST check the local scope, as two BlankNode in different
+	 * Graphs MUST differ. On the other hand, two BlankNodes found in triples
+	 * of the same Graph instance MUST equal if and only if they have the same
+	 * {@link #internalIdentifier()}.
+	 * <p>
+	 * Implementations MUST also override {@link #hashCode()} so that two equal
+	 * Literals produce the same hash code.
+	 * 
+	 * @see Object#equals(Object)
+	 * 
+	 * @param other
+	 * @return true if other is an BlankNode, is in the same local scope and is
+	 *         equal to this BlankNode
+	 */
+    @Override
+    public boolean equals(Object other);
+    
+    
+    /**
+	 * Calculate a hash code for this BlankNode.
+	 * <p>
+	 * This method MUST be implemented when implementing {@link #equals(Object)}
+	 * so that two equal BlankNodes produce the same hash code.
+	 * 
+	 * @see Object#hashCode()
+	 * 
+	 * @return a hash code value for this BlankNode.
+	 */
+    @Override
+    public int hashCode();    
 
 }

--- a/src/main/java/com/github/commonsrdf/api/IRI.java
+++ b/src/main/java/com/github/commonsrdf/api/IRI.java
@@ -39,9 +39,11 @@ public interface IRI extends BlankNodeOrIRI {
 	 * equality</a>: Two IRIs are equal if and only if they are equivalent under
 	 * Simple String Comparison according to section 5.1 of [RFC3987]. Further
 	 * normalization MUST NOT be performed when comparing IRIs for equality.
-	 * </blockquote> Two IRIs are equal are in the same local scope and their
-	 * {@link #getIRIString()} are equal. Implementations are not required to
-	 * check the local scope for IRI comparison.
+	 * </blockquote> 
+	 * <p>Two IRIs are equal are in the same local scope and their
+	 * {@link #getIRIString()} are equal. 
+	 * <p>
+	 * Implementations MAY check the local scope for IRI comparison.
 	 * <p>
 	 * Implementations MUST also override {@link #hashCode()} so that two equal
 	 * IRIs produce the same hash code.

--- a/src/main/java/com/github/commonsrdf/api/IRI.java
+++ b/src/main/java/com/github/commonsrdf/api/IRI.java
@@ -22,7 +22,7 @@ package com.github.commonsrdf.api;
 public interface IRI extends BlankNodeOrIRI {
 
 	/**
-	 * Returns the IRI encoded as a native Unicode String.<br>
+	 * Return the IRI encoded as a native Unicode String.<br>
 	 * 
 	 * The returned string must not include URL-encoding to escape 
 	 * non-ASCII characters.
@@ -30,4 +30,41 @@ public interface IRI extends BlankNodeOrIRI {
 	 * @return The IRI encoded as a native Unicode String.
 	 */
     String getIRIString();
+    
+    /**
+	 * Check it this IRI is equal to another IRI.
+	 * <p>
+	 * <blockquote cite="http://www.w3.org/TR/rdf11-concepts/#dfn-iri-equality"> <a
+	 * href="http://www.w3.org/TR/rdf11-concepts/#section-IRIs">IRI
+	 * equality</a>: Two IRIs are equal if and only if they are equivalent under
+	 * Simple String Comparison according to section 5.1 of [RFC3987]. Further
+	 * normalization MUST NOT be performed when comparing IRIs for equality.
+	 * </blockquote> Two IRIs are equal are in the same local scope and their
+	 * {@link #getIRIString()} are equal. Implementations are not required to
+	 * check the local scope for IRI comparison.
+	 * <p>
+	 * Implementations MUST also override {@link #hashCode()} so that two equal
+	 * IRIs produce the same hash code.
+	 * 
+	 * @see Object#equals(Object)
+	 * 
+	 * @param other
+	 * @return true if other is an IRI and is equal to this
+	 */
+    @Override
+    public boolean equals(Object other);
+    
+    
+    /**
+	 * Calculate a hash code for this IRI.
+	 * <p>
+	 * This method MUST be implemented when implementing {@link #equals(Object)}
+	 * so that two equal IRIs produce the same hash code.
+	 * 
+	 * @see Object#hashCode()
+	 * 
+	 * @return a hash code value for this IRI.
+	 */
+    @Override
+    public int hashCode();
 }

--- a/src/main/java/com/github/commonsrdf/api/Literal.java
+++ b/src/main/java/com/github/commonsrdf/api/Literal.java
@@ -77,7 +77,7 @@ public interface Literal extends RDFTerm {
 	 * literals can have the same value without being the same RDF term.
 	 * </blockquote>
 	 * <p>
-	 * Implementations are not required to check the local scope for Literal
+	 * Implementations MAY check the local scope for Literal
 	 * comparison.
 	 * <p>
 	 * Implementations MUST also override {@link #hashCode()} so that two equal

--- a/src/main/java/com/github/commonsrdf/api/Literal.java
+++ b/src/main/java/com/github/commonsrdf/api/Literal.java
@@ -65,5 +65,44 @@ public interface Literal extends RDFTerm {
      * Literal language tag</a>
      */
     Optional<String> getLanguageTag();
+    
+	/**
+	 * Check it this Literal is equal to another Literal.
+	 * <p>
+	 * <blockquote cite="http://www.w3.org/TR/rdf11-concepts/#dfn-literal-term">
+	 * <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal-term">Literal
+	 * term equality</a>: Two literals are term-equal (the same RDF literal) if
+	 * and only if the two lexical forms, the two datatype IRIs, and the two
+	 * language tags (if any) compare equal, character by character. Thus, two
+	 * literals can have the same value without being the same RDF term.
+	 * </blockquote>
+	 * <p>
+	 * Implementations are not required to check the local scope for Literal
+	 * comparison.
+	 * <p>
+	 * Implementations MUST also override {@link #hashCode()} so that two equal
+	 * Literals produce the same hash code.
+	 * 
+	 * @see Object#equals(Object)
+	 * 
+	 * @param other
+	 * @return true if other is an IRI and is equal to this
+	 */
+    @Override
+    public boolean equals(Object other);
+    
+    
+    /**
+	 * Calculate a hash code for this Literal.
+	 * <p>
+	 * This method MUST be implemented when implementing {@link #equals(Object)}
+	 * so that two equal Literals produce the same hash code.
+	 * 
+	 * @see Object#hashCode()
+	 * 
+	 * @return a hash code value for this Literal.
+	 */
+    @Override
+    public int hashCode();
 
 }

--- a/src/main/java/com/github/commonsrdf/api/Literal.java
+++ b/src/main/java/com/github/commonsrdf/api/Literal.java
@@ -16,7 +16,7 @@ package com.github.commonsrdf.api;
 import java.util.Optional;
 
 /**
- * An RDF-1.1 Literal, as defined by <a href=
+ * A RDF-1.1 Literal, as defined by <a href=
  * "http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal" >RDF-1.1
  * Concepts and Abstract Syntax</a>, a W3C Recommendation published on 25
  * February 2014
@@ -86,7 +86,7 @@ public interface Literal extends RDFTerm {
 	 * @see Object#equals(Object)
 	 * 
 	 * @param other
-	 * @return true if other is an IRI and is equal to this
+	 * @return true if other is a Literal and is equal to this
 	 */
     @Override
     public boolean equals(Object other);

--- a/src/main/java/com/github/commonsrdf/api/Triple.java
+++ b/src/main/java/com/github/commonsrdf/api/Triple.java
@@ -55,4 +55,40 @@ public interface Triple {
      */
     RDFTerm getObject();
 
+    /**
+	 * Check it this Triple is equal to another Triple.
+	 * <p>
+	 * <p>Two Triples are equal if and only if their
+	 * {@link #getSubject()}, {@link #getPredicate()} and {@link #getObject()}
+	 * are equal. 
+	 * <p>
+	 * Implementations MUST check the local scope for Triple comparison
+	 * if either the subject or object is a BlankNode, and MAY check the local
+	 * scope in other cases.
+	 * <p>
+	 * Implementations MUST also override {@link #hashCode()} so that two equal
+	 * Triples produce the same hash code.
+	 * 
+	 * @see Object#equals(Object)
+	 * 
+	 * @param other
+	 * @return true if other is a Triple and is equal to this
+	 */
+    @Override
+    public boolean equals(Object other);
+    
+    
+    /**
+	 * Calculate a hash code for this Triple.
+	 * <p>
+	 * This method MUST be implemented when implementing {@link #equals(Object)}
+	 * so that two equal IRIs produce the same hash code.
+	 * 
+	 * @see Object#hashCode()
+	 * 
+	 * @return a hash code value for this Triple.
+	 */
+    @Override
+    public int hashCode();
+    
 }


### PR DESCRIPTION
Implemented according to issue #45 for `Triple`, `IRI`, `Literal` and `BlankNode`. (But not for `Graph`.. that would be [isomorphism](http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism) rather than equivalence).

Obviously as `equals` and `hashCode` are always implemented by `java.lang.Object` these are just hints in an interface. (In an abstract class they could be made `abstract` to force implementations in subclasses)