### PR TITLE
Graph autocloseable

### DIFF
--- a/src/main/java/com/github/commonsrdf/api/Graph.java
+++ b/src/main/java/com/github/commonsrdf/api/Graph.java
@@ -43,6 +43,21 @@ public interface Graph extends AutoCloseable {
      */
     void add(BlankNodeOrIRI subject, IRI predicate, RDFTerm object);
 
+	/**
+	 * Close the graph, relinquishing any underlying resources.
+	 * <p>
+	 * For example, this would close any open file and network streams and free
+	 * database locks held by the Graph implementation.
+	 * <p>
+	 * The behaviour of the other Graph methods are undefined after closing the
+	 * graph.
+	 * <p>
+	 * Implementations might not need {@link #close()}, hence the default
+	 * implementation does nothing.
+	 */
+    @Override
+    default void close() throws Exception {}
+    
     /**
      * Check if graph contains triple.
      *

--- a/src/main/java/org/apache/commons/rdf/Graph.java
+++ b/src/main/java/org/apache/commons/rdf/Graph.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
  * href="http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1 Concepts and Abstract
  * Syntax</a>, a W3C Recommendation published on 25 February 2014.
  */
-public interface Graph {
+public interface Graph extends AutoCloseable {
 
     /**
      * Add a triple to the graph.


### PR DESCRIPTION
Make `Graph` extend `AutoClosable`, with default implementation
    
.. and javadoc.
    
Modifies @ansell's pull request #31
according to
https://github.com/commons-rdf/commons-rdf/issues/29#issuecomment-69910819
