### PR TITLE
Add Types enum with RDF and XML Schema type IRIs, fixes #17

### DIFF
--- a/simple/src/main/java/com/github/commonsrdf/simple/LiteralImpl.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/LiteralImpl.java
@@ -34,14 +34,13 @@ class LiteralImpl implements Literal {
 	private String lexicalForm;
 
 	public LiteralImpl(String literal) {
-		this.lexicalForm = Objects.requireNonNull(literal);
-		this.dataType = Types.XSD_STRING;
-		this.languageTag = Optional.empty();
+		this(literal, Types.XSD_STRING);
 	}
 
 	public LiteralImpl(String lexicalForm, IRI dataType) {
 		this.lexicalForm = Objects.requireNonNull(lexicalForm);
-		this.dataType = Objects.requireNonNull(dataType);
+		this.dataType = Types.get(Objects.requireNonNull(dataType)).orElse(
+				dataType);
 		this.languageTag = Optional.empty();
 	}
 

--- a/simple/src/main/java/com/github/commonsrdf/simple/LiteralImpl.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/LiteralImpl.java
@@ -28,10 +28,6 @@ import com.github.commonsrdf.api.Literal;
 class LiteralImpl implements Literal {
 
 	private static final String QUOTE = "\"";
-	private static final IRIImpl RDF_LANG_STRING = new IRIImpl(
-			"http://www.w3.org/1999/02/22-rdf-syntax-ns#langString");
-	private static final IRIImpl XSD_STRING = new IRIImpl(
-			"http://www.w3.org/2001/XMLSchema#string");
 
 	private IRI dataType;
 	private Optional<String> languageTag;
@@ -39,7 +35,7 @@ class LiteralImpl implements Literal {
 
 	public LiteralImpl(String literal) {
 		this.lexicalForm = Objects.requireNonNull(literal);
-		this.dataType = XSD_STRING;
+		this.dataType = Types.XSD_STRING;
 		this.languageTag = Optional.empty();
 	}
 
@@ -65,7 +61,7 @@ class LiteralImpl implements Literal {
 		}
 
 		// System.out.println(aLocale);
-		this.dataType = RDF_LANG_STRING;
+		this.dataType = Types.RDF_LANGSTRING;
 	}
 
 	@Override
@@ -99,7 +95,7 @@ class LiteralImpl implements Literal {
 			sb.append("@");
 			sb.append(getLanguageTag().get());
 
-		} else if (!getDatatype().equals(XSD_STRING)) {
+		} else if (!getDatatype().equals(Types.XSD_STRING)) {
 			sb.append("^^");
 			sb.append(getDatatype().ntriplesString());
 		}

--- a/simple/src/main/java/com/github/commonsrdf/simple/SimpleRDFTermFactory.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/SimpleRDFTermFactory.java
@@ -51,7 +51,9 @@ public class SimpleRDFTermFactory implements RDFTermFactory {
 
 	@Override
 	public IRI createIRI(String iri) {
-		return new IRIImpl(iri);
+		IRI result = new IRIImpl(iri);
+		// Reuse any IRI objects already created in Types
+		return Types.get(result).orElse(result);
 	}
 
 	@Override

--- a/simple/src/main/java/com/github/commonsrdf/simple/Types.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/Types.java
@@ -13,6 +13,8 @@
  */
 package com.github.commonsrdf.simple;
 
+import java.util.Optional;
+
 import com.github.commonsrdf.api.IRI;
 
 /**
@@ -168,5 +170,14 @@ public enum Types implements IRI {
 	@Override
 	public String ntriplesString() {
 		return this.field.ntriplesString();
+	}
+	
+	public static Optional<IRI> get(IRI nextIRI) {
+		for(IRI nextType : values()) {
+			if(nextType.equals(nextIRI)) {
+				return Optional.of(nextType); 
+			}
+		}
+		return Optional.empty();
 	}
 }

--- a/simple/src/main/java/com/github/commonsrdf/simple/Types.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/Types.java
@@ -182,8 +182,8 @@ public enum Types implements IRI {
 	 *         {@link Optional#empty()} if it is not present here.
 	 */
 	public static Optional<IRI> get(IRI nextIRI) {
-		for (IRI nextType : values()) {
-			if (nextType.equals(nextIRI)) {
+		for (Types nextType : values()) {
+			if (nextType.field.equals(nextIRI)) {
 				return Optional.of(nextType);
 			}
 		}

--- a/simple/src/main/java/com/github/commonsrdf/simple/Types.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/Types.java
@@ -69,12 +69,6 @@ public enum Types implements IRI {
 	/** <tt>http://www.w3.org/2001/XMLSchema#duration</tt> */
 	XSD_DURATION("http://www.w3.org/2001/XMLSchema#duration"),
 
-	/** <tt>http://www.w3.org/2001/XMLSchema#ENTITIES</tt> */
-	XSD_ENTITIES("http://www.w3.org/2001/XMLSchema#ENTITIES"),
-
-	/** <tt>http://www.w3.org/2001/XMLSchema#ENTITY</tt> */
-	XSD_ENTITY("http://www.w3.org/2001/XMLSchema#ENTITY"),
-
 	/** <tt>http://www.w3.org/2001/XMLSchema#float</tt> */
 	XSD_FLOAT("http://www.w3.org/2001/XMLSchema#float"),
 
@@ -95,15 +89,6 @@ public enum Types implements IRI {
 
 	/** <tt>http://www.w3.org/2001/XMLSchema#hexBinary</tt> */
 	XSD_HEXBINARY("http://www.w3.org/2001/XMLSchema#hexBinary"),
-
-	/** <tt>http://www.w3.org/2001/XMLSchema#ID</tt> */
-	XSD_ID("http://www.w3.org/2001/XMLSchema#ID"),
-
-	/** <tt>http://www.w3.org/2001/XMLSchema#IDREF</tt> */
-	XSD_IDREF("http://www.w3.org/2001/XMLSchema#IDREF"),
-
-	/** <tt>http://www.w3.org/2001/XMLSchema#IDREFS</tt> */
-	XSD_IDREFS("http://www.w3.org/2001/XMLSchema#IDREFS"),
 
 	/** <tt>http://www.w3.org/2001/XMLSchema#int</tt> */
 	XSD_INT("http://www.w3.org/2001/XMLSchema#int"),
@@ -129,9 +114,6 @@ public enum Types implements IRI {
 	/** <tt>http://www.w3.org/2001/XMLSchema#NMTOKEN</tt> */
 	XSD_NMTOKEN("http://www.w3.org/2001/XMLSchema#NMTOKEN"),
 
-	/** <tt>http://www.w3.org/2001/XMLSchema#NMTOKENS</tt> */
-	XSD_NMTOKENS("http://www.w3.org/2001/XMLSchema#NMTOKENS"),
-
 	/** <tt>http://www.w3.org/2001/XMLSchema#nonNegativeInteger</tt> */
 	XSD_NONNEGATIVEINTEGER(
 			"http://www.w3.org/2001/XMLSchema#nonNegativeInteger"),
@@ -143,14 +125,8 @@ public enum Types implements IRI {
 	/** <tt>http://www.w3.org/2001/XMLSchema#normalizedString</tt> */
 	XSD_NORMALIZEDSTRING("http://www.w3.org/2001/XMLSchema#normalizedString"),
 
-	/** <tt>http://www.w3.org/2001/XMLSchema#NOTATION</tt> */
-	XSD_NOTATION("http://www.w3.org/2001/XMLSchema#NOTATION"),
-
 	/** <tt>http://www.w3.org/2001/XMLSchema#positiveInteger</tt> */
 	XSD_POSITIVEINTEGER("http://www.w3.org/2001/XMLSchema#positiveInteger"),
-
-	/** <tt>http://www.w3.org/2001/XMLSchema#QName</tt> */
-	XSD_QNAME("http://www.w3.org/2001/XMLSchema#QName"),
 
 	/** <tt>http://www.w3.org/2001/XMLSchema#short</tt> */
 	XSD_SHORT("http://www.w3.org/2001/XMLSchema#short"),

--- a/simple/src/main/java/com/github/commonsrdf/simple/Types.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/Types.java
@@ -171,11 +171,20 @@ public enum Types implements IRI {
 	public String ntriplesString() {
 		return this.field.ntriplesString();
 	}
-	
+
+	/**
+	 * Get the IRI from this enum if it is present, or return
+	 * {@link Optional#empty()} otherwise.
+	 * 
+	 * @param nextIRI
+	 *            The IRI to look for.
+	 * @return An {@link Optional} containing the IRI from this enum or
+	 *         {@link Optional#empty()} if it is not present here.
+	 */
 	public static Optional<IRI> get(IRI nextIRI) {
-		for(IRI nextType : values()) {
-			if(nextType.equals(nextIRI)) {
-				return Optional.of(nextType); 
+		for (IRI nextType : values()) {
+			if (nextType.equals(nextIRI)) {
+				return Optional.of(nextType);
 			}
 		}
 		return Optional.empty();

--- a/simple/src/main/java/com/github/commonsrdf/simple/Types.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/Types.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.commonsrdf.simple;
+
+import com.github.commonsrdf.api.IRI;
+
+/**
+ * Types from the RDF and XML Schema vocabularies.
+ * 
+ * @author Peter Ansell p_ansell@yahoo.com
+ */
+public enum Types implements IRI {
+
+	/** <tt>http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML</tt> */
+	RDF_HTML("http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"),
+
+	/** <tt>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</tt> */
+	RDF_LANGSTRING("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"),
+
+	/**
+	 * <tt>http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral</tt>
+	 * 
+	 * @deprecated Not used in RDF-1.1
+	 */
+	@Deprecated
+	RDF_PLAINLITERAL("http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"),
+
+	/** <tt>http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral</tt> */
+	RDF_XMLLITERAL("http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#anyURI</tt> */
+	XSD_ANYURI("http://www.w3.org/2001/XMLSchema#anyURI"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#base64Binary</tt> */
+	XSD_BASE64BINARY("http://www.w3.org/2001/XMLSchema#base64Binary"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#boolean</tt> */
+	XSD_BOOLEAN("http://www.w3.org/2001/XMLSchema#boolean"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#byte</tt> */
+	XSD_BYTE("http://www.w3.org/2001/XMLSchema#byte"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#date</tt> */
+	XSD_DATE("http://www.w3.org/2001/XMLSchema#date"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#dateTime</tt> */
+	XSD_DATETIME("http://www.w3.org/2001/XMLSchema#dateTime"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#dayTimeDuration</tt> */
+	XSD_DAYTIMEDURATION("http://www.w3.org/2001/XMLSchema#dayTimeDuration"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#decimal</tt> */
+	XSD_DECIMAL("http://www.w3.org/2001/XMLSchema#decimal"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#double</tt> */
+	XSD_DOUBLE("http://www.w3.org/2001/XMLSchema#double"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#duration</tt> */
+	XSD_DURATION("http://www.w3.org/2001/XMLSchema#duration"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#ENTITIES</tt> */
+	XSD_ENTITIES("http://www.w3.org/2001/XMLSchema#ENTITIES"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#ENTITY</tt> */
+	XSD_ENTITY("http://www.w3.org/2001/XMLSchema#ENTITY"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#float</tt> */
+	XSD_FLOAT("http://www.w3.org/2001/XMLSchema#float"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#gDay</tt> */
+	XSD_GDAY("http://www.w3.org/2001/XMLSchema#gDay"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#gMonth</tt> */
+	XSD_GMONTH("http://www.w3.org/2001/XMLSchema#gMonth"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#gMonthDay</tt> */
+	XSD_GMONTHDAY("http://www.w3.org/2001/XMLSchema#gMonthDay"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#gYear</tt> */
+	XSD_GYEAR("http://www.w3.org/2001/XMLSchema#gYear"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#gYearMonth</tt> */
+	XSD_GYEARMONTH("http://www.w3.org/2001/XMLSchema#gYearMonth"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#hexBinary</tt> */
+	XSD_HEXBINARY("http://www.w3.org/2001/XMLSchema#hexBinary"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#ID</tt> */
+	XSD_ID("http://www.w3.org/2001/XMLSchema#ID"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#IDREF</tt> */
+	XSD_IDREF("http://www.w3.org/2001/XMLSchema#IDREF"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#IDREFS</tt> */
+	XSD_IDREFS("http://www.w3.org/2001/XMLSchema#IDREFS"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#int</tt> */
+	XSD_INT("http://www.w3.org/2001/XMLSchema#int"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#integer</tt> */
+	XSD_INTEGER("http://www.w3.org/2001/XMLSchema#integer"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#language</tt> */
+	XSD_LANGUAGE("http://www.w3.org/2001/XMLSchema#language"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#long</tt> */
+	XSD_LONG("http://www.w3.org/2001/XMLSchema#long"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#Name</tt> */
+	XSD_NAME("http://www.w3.org/2001/XMLSchema#Name"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#NCName</tt> */
+	XSD_NCNAME("http://www.w3.org/2001/XMLSchema#NCName"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#negativeInteger</tt> */
+	XSD_NEGATIVEINTEGER("http://www.w3.org/2001/XMLSchema#negativeInteger"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#NMTOKEN</tt> */
+	XSD_NMTOKEN("http://www.w3.org/2001/XMLSchema#NMTOKEN"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#NMTOKENS</tt> */
+	XSD_NMTOKENS("http://www.w3.org/2001/XMLSchema#NMTOKENS"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#nonNegativeInteger</tt> */
+	XSD_NONNEGATIVEINTEGER(
+			"http://www.w3.org/2001/XMLSchema#nonNegativeInteger"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#nonPositiveInteger</tt> */
+	XSD_NONPOSITIVEINTEGER(
+			"http://www.w3.org/2001/XMLSchema#nonPositiveInteger"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#normalizedString</tt> */
+	XSD_NORMALIZEDSTRING("http://www.w3.org/2001/XMLSchema#normalizedString"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#NOTATION</tt> */
+	XSD_NOTATION("http://www.w3.org/2001/XMLSchema#NOTATION"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#positiveInteger</tt> */
+	XSD_POSITIVEINTEGER("http://www.w3.org/2001/XMLSchema#positiveInteger"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#QName</tt> */
+	XSD_QNAME("http://www.w3.org/2001/XMLSchema#QName"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#short</tt> */
+	XSD_SHORT("http://www.w3.org/2001/XMLSchema#short"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#string</tt> */
+	XSD_STRING("http://www.w3.org/2001/XMLSchema#string"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#time</tt> */
+	XSD_TIME("http://www.w3.org/2001/XMLSchema#time"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#token</tt> */
+	XSD_TOKEN("http://www.w3.org/2001/XMLSchema#token"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#unsignedByte</tt> */
+	XSD_UNSIGNEDBYTE("http://www.w3.org/2001/XMLSchema#unsignedByte"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#unsignedInt</tt> */
+	XSD_UNSIGNEDINT("http://www.w3.org/2001/XMLSchema#unsignedInt"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#unsignedLong</tt> */
+	XSD_UNSIGNEDLONG("http://www.w3.org/2001/XMLSchema#unsignedLong"),
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#unsignedShort</tt> */
+	XSD_UNSIGNEDSHORT("http://www.w3.org/2001/XMLSchema#unsignedShort"),
+
+	;
+
+	private final IRI field;
+
+	Types(String field) {
+		this.field = new IRIImpl(field);
+	}
+
+	@Override
+	public String getIRIString() {
+		return this.field.getIRIString();
+	}
+
+	@Override
+	public String ntriplesString() {
+		return this.field.ntriplesString();
+	}
+}

--- a/simple/src/test/java/com/github/commonsrdf/simple/TypesTest.java
+++ b/simple/src/test/java/com/github/commonsrdf/simple/TypesTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.commonsrdf.simple;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link Types} enumeration.
+ * 
+ * @author Peter Ansell p_ansell@yahoo.com
+ */
+public class TypesTest {
+
+	/**
+	 * Test method for {@link com.github.commonsrdf.simple.Types#getIRIString()}
+	 * .
+	 */
+	@Test
+	public final void testGetIRIString() {
+		assertEquals("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
+				Types.RDF_LANGSTRING.getIRIString());
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.commonsrdf.simple.Types#ntriplesString()}.
+	 */
+	@Test
+	public final void testNtriplesString() {
+		assertEquals("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>",
+				Types.RDF_LANGSTRING.ntriplesString());
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.commonsrdf.simple.Types#get(com.github.commonsrdf.api.IRI)}
+	 * .
+	 */
+	@Test
+	public final void testGet() {
+		assertTrue(Types.get(
+				new IRIImpl("http://www.w3.org/2001/XMLSchema#boolean"))
+				.isPresent());
+		assertEquals(
+				"http://www.w3.org/2001/XMLSchema#boolean",
+				Types.get(
+						new IRIImpl("http://www.w3.org/2001/XMLSchema#boolean"))
+						.get().getIRIString());
+		assertFalse(Types.get(
+				new IRIImpl("http://www.w3.org/2001/XMLSchema#nonExistent"))
+				.isPresent());
+	}
+
+}


### PR DESCRIPTION
Add a Types enum with all of the datatypes from RDF and XML Schema to the simple implementation.