### PR TITLE
Ntriples for bnodes

### DIFF
--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -18,11 +18,11 @@ package com.github.commonsrdf.api;
  * Blank Node</a>, as defined by <a href=
  * "http://www.w3.org/TR/rdf11-concepts/#section-blank-nodes" >RDF-1.1 Concepts
  * and Abstract Syntax</a>, a W3C Recommendation published on 25 February 2014.<br>
- *
+ * <p>
  * Note that: Blank nodes are disjoint from IRIs and literals. Otherwise, the
  * set of possible blank nodes is arbitrary. RDF makes no reference to any
  * internal structure of blank nodes.
- *
+ * <p>
  * Also note that: Blank node identifiers are local identifiers that are used in
  * some concrete RDF syntaxes or RDF store implementations. They are always
  * locally scoped to the file or RDF store, and are not persistent or portable
@@ -46,17 +46,17 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * >label</a> for the blank node. This is not a serialization/syntax label.
 	 * It should be uniquely identifying within the local scope it is created in
 	 * but has no uniqueness guarantees other than that.
-	 *
+	 * <p>
 	 * In particular, the existence of two objects of type {@link BlankNode}
 	 * with the same value returned from {@link #internalIdentifier()} are not
 	 * equivalent unless they are known to have been created in the same local
-	 * scope.
-	 *
+	 * scope (see {@link #equals(Object)})
+	 * <p>
 	 * An example of a local scope may be an instance of a Java Virtual Machine
 	 * (JVM). In the context of a JVM instance, an implementor may support
 	 * insertion and removal of {@link Triple} objects containing Blank Nodes
 	 * without modifying the blank node labels.
-	 *
+	 * <p>
 	 * Another example of a local scope may be a <a
 	 * href="http://www.w3.org/TR/rdf11-concepts/#section-rdf-graph">Graph</a>
 	 * or <a
@@ -67,11 +67,16 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * guarantee that it is unique for the JVM instance. In this case, the
 	 * implementor may support a mechanism to provide a mapping for blank nodes
 	 * between Graph or Dataset instances to guarantee their uniqueness.
-	 *
+	 * <p>
 	 * If implementors support <a
 	 * href="http://www.w3.org/TR/rdf11-concepts/#section-skolemization"
 	 * >Skolemisation</a>, they may map instances of {@link BlankNode} objects
 	 * to {@link IRI} objects to reduce scoping issues.
+	 * <p>
+	 * It is not a requirement for the internal identifier to be a part of the
+	 * {@link #ntriplesString()}, except that two BlankNode instances with the
+	 * same internalIdentifier() and same local scope should have the same
+	 * {@link #ntriplesString()}.
 	 *
 	 * @return An internal, system identifier for the {@link BlankNode}.
 	 */

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -337,15 +337,22 @@ public abstract class AbstractRDFTermFactoryTest {
 		factory = createFactory();
 	}
 
-	@Test(expected = Exception.class)
-	public void invalidBlankNode() throws Exception {
+	@Test
+	public void possiblyInvalidBlankNode() throws Exception {		
+		BlankNode withColon;
 		try {
-			factory.createBlankNode("with:colon").ntriplesString();
+			withColon = factory.createBlankNode("with:colon");
 		} catch (UnsupportedOperationException ex) {
 			Assume.assumeNoException("createBlankNode(String) not supported",
 					ex);
 			return;
+		} catch (IllegalArgumentException ex){			
+			// Good!
+			return;
 		}
+		// Factory allows :colon, which is OK as long as it's not causing an
+		// invalid ntriplesString
+		assertFalse(withColon.ntriplesString().contains("with:colon"));		
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Assume;
 import org.junit.Before;
@@ -352,7 +351,11 @@ public abstract class AbstractRDFTermFactoryTest {
 		}
 		// Factory allows :colon, which is OK as long as it's not causing an
 		// invalid ntriplesString
-		assertFalse(withColon.ntriplesString().contains("with:colon"));		
+		assertFalse(withColon.ntriplesString().contains("with:colon"));
+		
+		// and creating it twice gets the same ntriplesString		
+		assertEquals(withColon.ntriplesString(),
+				factory.createBlankNode("with:colon").ntriplesString());
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -46,19 +46,11 @@ public abstract class AbstractRDFTermFactoryTest {
 			Assume.assumeNoException(ex);
 			return;
 		}
-		String ntriplesString = bnode.ntriplesString();
-		assertTrue("ntriples must start with _:",
-				ntriplesString.startsWith("_:"));
-		assertTrue("Internal identifier can't be empty", bnode
-				.internalIdentifier().length() > 0);
-		assertEquals("ntriples does not correspond with internal identifier",
-				bnode.internalIdentifier(),
-				ntriplesString.substring(2, ntriplesString.length()));
 
 		BlankNode bnode2 = factory.createBlankNode();
 		assertNotEquals(
 				"Second blank node has not got a unique internal identifier",
-				bnode.internalIdentifier(), bnode2.internalIdentifier());
+				bnode.internalIdentifier(), bnode2.internalIdentifier());		
 	}
 
 	@Test
@@ -71,9 +63,30 @@ public abstract class AbstractRDFTermFactoryTest {
 			return;
 		}
 		assertEquals("example1", bnode.internalIdentifier());
-		assertEquals("_:example1", bnode.ntriplesString());
+		// .. but we can't assume the internal identifier leaks into
+		// ntriplesString
+		//assertEquals("_:example1", bnode.ntriplesString());
 	}
 
+	@Test
+	public void createBlankNodeIdentifierTwice() throws Exception {
+		BlankNode bnode1, bnode2, bnode3;
+		try {
+			bnode1 = factory.createBlankNode("example1");
+			bnode2 = factory.createBlankNode("example1");
+			bnode3 = factory.createBlankNode("differ");
+		} catch (UnsupportedOperationException ex) {
+			Assume.assumeNoException(ex);
+			return;
+		}
+		assertEquals(bnode1.internalIdentifier(), bnode2.internalIdentifier());
+		// We don't know what the ntriplesString is, but it MUST be the same
+		assertEquals(bnode1.ntriplesString(), bnode2.ntriplesString());
+		// and here it MUST differ
+		assertNotEquals(bnode1.ntriplesString(), bnode3.ntriplesString());
+	}
+
+	
 	public abstract RDFTermFactory createFactory();
 
 	@Test
@@ -266,15 +279,11 @@ public abstract class AbstractRDFTermFactoryTest {
 			return;
 		}
 
-		// NOTE: We do not require object equivalence after insertion,
-		// but the ntriples should match
-		assertEquals(subject.ntriplesString(), triple.getSubject()
-				.ntriplesString());
-		assertEquals(predicate.ntriplesString(), triple.getPredicate()
-				.ntriplesString());
-		assertEquals(object.ntriplesString(), triple.getObject()
-				.ntriplesString());
-
+		// bnode equivalence should be OK as we used the same
+		// factory and have not yet inserted Triple into a Graph
+		assertEquals(subject, triple.getSubject());		
+		assertEquals(predicate, triple.getPredicate());
+		assertEquals(object, triple.getObject());
 	}
 
 	@Test
@@ -293,14 +302,11 @@ public abstract class AbstractRDFTermFactoryTest {
 			return;
 		}
 
-		// NOTE: We do not require object equivalence after insertion,
-		// but the ntriples should match
-		assertEquals(subject.ntriplesString(), triple.getSubject()
-				.ntriplesString());
-		assertEquals(predicate.ntriplesString(), triple.getPredicate()
-				.ntriplesString());
-		assertEquals(object.ntriplesString(), triple.getObject()
-				.ntriplesString());
+		// bnode equivalence should be OK as we used the same
+		// factory and have not yet inserted Triple into a Graph
+		assertEquals(subject, triple.getSubject());		
+		assertEquals(predicate, triple.getPredicate());
+		assertEquals(object, triple.getObject());
 	}
 
 	@Test
@@ -319,14 +325,11 @@ public abstract class AbstractRDFTermFactoryTest {
 			return;
 		}
 
-		// NOTE: We do not require object equivalence after insertion,
-		// but the ntriples should match
-		assertEquals(subject.ntriplesString(), triple.getSubject()
-				.ntriplesString());
-		assertEquals(predicate.ntriplesString(), triple.getPredicate()
-				.ntriplesString());
-		assertEquals(object.ntriplesString(), triple.getObject()
-				.ntriplesString());
+		// bnode equivalence should be OK as we used the same
+		// factory and have not yet inserted Triple into a Graph
+		assertEquals(subject, triple.getSubject());		
+		assertEquals(predicate, triple.getPredicate());
+		assertEquals(object, triple.getObject());
 	}
 
 	@Before

--- a/simple/src/main/java/com/github/commonsrdf/simple/BlankNodeImpl.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/BlankNodeImpl.java
@@ -13,8 +13,10 @@
  */
 package com.github.commonsrdf.simple;
 
+import java.nio.charset.Charset;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.github.commonsrdf.api.BlankNode;
@@ -26,6 +28,7 @@ import com.github.commonsrdf.api.Graph;
  */
 class BlankNodeImpl implements BlankNode {
 
+	private static final Charset UTF8 = Charset.forName("UTF-8");
 	private static AtomicLong bnodeCounter = new AtomicLong();
 	private String id;
 	private Optional<Graph> localScope;
@@ -52,10 +55,7 @@ class BlankNodeImpl implements BlankNode {
 	@Override
 	public String ntriplesString() {
 		if (id.contains(":")) {
-			// FIXME: Perhaps do a SHA hash of the id?
-			throw new IllegalStateException(
-					"Blank node identifier can't be expressed as ntriples string: "
-							+ id);
+			return "_:u" + UUID.nameUUIDFromBytes(id.getBytes(UTF8));
 		}
 		return "_:" + id;
 	}


### PR DESCRIPTION
Tests now don't rely on `BlankNode.ntriplesString()` being related to `BlankNode.internalIdentifier()`.
    
As pointed out in #42, the `ntriplesString()` is not required to match the internal identifier. This is now clarified in `BlankNode`.
    
Rather than comparing ntriplesStrings, the tests now also use the fact that `RDFNode`s in a Triple are equal to those passed into the RDFTermFactory.createTriple() - as those terms were also made with the same RDFTermFactory and the Triple is not (yet) inserted into a graph. (See #47).

The only comparison of BlankNode ntriplesString are now done to test that `RDFTermFactory.createBlankNode(String)` twice with the same identifier provide ntriplesStrings that match.