### PR TITLE
Corrected pom SCM info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,11 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
+    <url>http://commons-rdf.github.io/</url>
     <scm>
         <connection>scm:git:https://github.com/commons-rdf/commons-rdf.git</connection>
         <developerConnection>scm:git:git@github.com:commons-rdf/commons-rdf.git</developerConnection>
-        <url>http://commons-rdf.github.io/</url>
+        <url>https://github.com/commons-rdf/commons-rdf/</url>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
     </properties>
 
     <scm>
-        <connection>scm:git:git@github.com:commons-rdf/commons-rdf.git</connection>
+        <connection>scm:git:https://github.com/commons-rdf/commons-rdf.git</connection>
         <developerConnection>scm:git:git@github.com:commons-rdf/commons-rdf.git</developerConnection>
-        <url>git@github.com:commons-rdf/commons-rdf.git</url>
+        <url>http://commons-rdf.github.io/</url>
     </scm>
 
     <licenses>


### PR DESCRIPTION
the non-developer `<connection>` should now work even without Github account with SSH key (and through funny firewalls..? :)).

`<url>` updated.