### PR TITLE
Blanknode blockquotes

### DIFF
--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -32,8 +32,10 @@ package com.github.commonsrdf.api;
  * <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">Blank node identifiers</a>
  * are local identifiers that are used in
  * some concrete RDF syntaxes or RDF store implementations. They are always
- * <em>locally scoped</em> to the file or RDF store, and are not persistent or portable
- * identifiers for blank nodes. Blank node identifiers are not part of the RDF
+ * <em>locally scoped</em> to the file or RDF store, and are <em>not</em> persistent 
+ * or portable
+ * identifiers for blank nodes. Blank node identifiers are <em>not</em> 
+ * part of the RDF
  * abstract syntax, but are entirely dependent on the concrete syntax or
  * implementation.
  * The syntactic restrictions on blank node identifiers, if any,
@@ -103,10 +105,12 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * of the RDF abstract syntax, but are entirely dependent on the concrete
 	 * syntax or implementation. The syntactic restrictions on blank node
 	 * identifiers, if any, therefore also depend on the concrete RDF syntax or
-	 * implementation. Implementations that handle blank node identifiers in
+	 * implementation. 
+	 * <p>Implementations that handle blank node identifiers in
 	 * concrete syntaxes need to be careful not to create the same blank node
 	 * from multiple occurrences of the same blank node identifier except in
-	 * situations where this is supported by the syntax. </blockquote>
+	 * situations where this is supported by the syntax. 
+	 * </blockquote>
 	 * <p>
 	 * Implementations MUST check the local scope, as two BlankNode in different
 	 * Graphs MUST differ. On the other hand, two BlankNodes found in triples of

--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -19,11 +19,18 @@ package com.github.commonsrdf.api;
  * "http://www.w3.org/TR/rdf11-concepts/#section-blank-nodes" >RDF-1.1 Concepts
  * and Abstract Syntax</a>, a W3C Recommendation published on 25 February 2014.<br>
  * <p>
- * Note that: Blank nodes are disjoint from IRIs and literals. Otherwise, the
- * set of possible blank nodes is arbitrary. RDF makes no reference to any
- * internal structure of blank nodes.
+ * Note: 
+ * <blockquote cite="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node">
+ *   <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node">Blank nodes</a>
+ *   are disjoint from IRIs and literals. Otherwise, the
+ *   set of possible blank nodes is arbitrary. RDF makes no reference to any
+ *   internal structure of blank nodes.
+ * </blockquote>
  * <p>
- * Also note that: Blank node identifiers are local identifiers that are used in
+ * Also note that: 
+ * <blockquote cite="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">
+ *   <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">Blank node identifiers</a>
+ *   are local identifiers that are used in
  * some concrete RDF syntaxes or RDF store implementations. They are always
  * locally scoped to the file or RDF store, and are not persistent or portable
  * identifiers for blank nodes. Blank node identifiers are not part of the RDF
@@ -34,8 +41,9 @@ package com.github.commonsrdf.api;
  * to be careful not to create the same blank node from multiple occurrences of
  * the same blank node identifier except in situations where this is supported
  * by the syntax.
+ * </blockquote>
  *
- * @see <a href= "http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node">RDF-1.1
+ * @see <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node">RDF-1.1
  *      Blank Node</a>
  */
 public interface BlankNode extends BlankNodeOrIRI {

--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -29,14 +29,16 @@ package com.github.commonsrdf.api;
  * <p>
  * Also note that: 
  * <blockquote cite="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">
- *   <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">Blank node identifiers</a>
- *   are local identifiers that are used in
+ * <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">Blank node identifiers</a>
+ * are local identifiers that are used in
  * some concrete RDF syntaxes or RDF store implementations. They are always
- * locally scoped to the file or RDF store, and are not persistent or portable
+ * <em>locally scoped</em> to the file or RDF store, and are not persistent or portable
  * identifiers for blank nodes. Blank node identifiers are not part of the RDF
  * abstract syntax, but are entirely dependent on the concrete syntax or
- * implementation. The syntactic restrictions on blank node identifiers, if any,
+ * implementation.
+ * The syntactic restrictions on blank node identifiers, if any,
  * therefore also depend on the concrete RDF syntax or implementation.
+ * <p>
  * Implementations that handle blank node identifiers in concrete syntaxes need
  * to be careful not to create the same blank node from multiple occurrences of
  * the same blank node identifier except in situations where this is supported


### PR DESCRIPTION
Trying to make the javadoc in BlankNode a bit more readable typographically speaking by introducing a few strategic paragraphs. 

This patch does not considering the other issues with BlankNode "local" identities.

