### PR TITLE
Blanknode identifier only

### DIFF
--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -58,8 +58,12 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * Return a <a href=
 	 * "http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier"
 	 * >identifier</a> for the blank node as an {@link UUID}. 
-	 * This is not a serialization/syntax label.
-	 * It uniquely identify the blank node, but does not
+	 * <p>
+	 * This is <strong>not</strong> a serialization/syntax label, 
+	 * e.g. not of the type <del><code>_:b2</code></del>.
+	 * <p>
+	 * The returned string MUST uniquely identify the 
+	 * only this blank node, but but does not
 	 * come with any guarantees for persistence or resolution.
 	 * <p>
 	 * Two objects of the type <code>BlankNode</code> with the same
@@ -71,14 +75,21 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * with different <code>identifier()</code> values are not 
 	 * necessarily different.
 	 * <p>
-	 * It is not a requirement for this UUID <code>identifier</code> 
+	 * The identifier MUST be globally unique. It is RECOMMENDED 
+	 * for the identifier to be a UUID string.
+	 * If the identifier is a IRI, it is SHOULD be a  
+	 * <a href="http://www.w3.org/TR/rdf11-concepts/#section-skolemization">
+	 * skolem IRI</a>.
+	 * <p>
+	 * It is not a requirement for this <code>identifier</code> 
 	 * to form part of the {@link #ntriplesString()}. 
 	 *
+	 * @see UUID#toString()
 	 * @see #equals(Object)
 	 *
 	 * @return An unique identifier for the {@link BlankNode}.
 	 */
-	UUID identifier();
+	 String identifier();
 
 	/**
 	 * Check it this BlankNode is equal to another BlankNode.

--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -59,7 +59,7 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * "http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier"
 	 * >identifier</a> for the blank node as an {@link UUID}. 
 	 * This is not a serialization/syntax label.
-	 * It should be uniquely identifying the blank node, but does not
+	 * It uniquely identify the blank node, but does not
 	 * come with any guarantees for persistence or resolution.
 	 * <p>
 	 * Two objects of the type <code>BlankNode</code> with the same
@@ -71,8 +71,8 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * with different <code>identifier()</code> values are not 
 	 * necessarily different.
 	 * <p>
-	 * It is not a requirement for this UUID <code>identifier</code> to form part of the
-	 * {@link #ntriplesString()}. 
+	 * It is not a requirement for this UUID <code>identifier</code> 
+	 * to form part of the {@link #ntriplesString()}. 
 	 *
 	 * @see #equals(Object)
 	 *

--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -60,7 +60,7 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * >identifier</a> for the blank node as an {@link UUID}. 
 	 * <p>
 	 * This is <strong>not</strong> a serialization/syntax label, 
-	 * e.g. not of the type <del><code>_:b2</code></del>.
+	 * e.g. not <del><code>_:b2</code></del>.
 	 * <p>
 	 * The returned string MUST uniquely identify the 
 	 * only this blank node, but but does not
@@ -81,7 +81,7 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * <a href="http://www.w3.org/TR/rdf11-concepts/#section-skolemization">
 	 * skolem IRI</a>.
 	 * <p>
-	 * It is not a requirement for this <code>identifier</code> 
+	 * It is NOT RECOMMENDED for this <code>identifier</code> 
 	 * to form part of the {@link #ntriplesString()}. 
 	 *
 	 * @see UUID#toString()

--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -13,6 +13,8 @@
  */
 package com.github.commonsrdf.api;
 
+import java.util.UUID;
+
 /**
  * A <a href= "http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node" >RDF-1.1
  * Blank Node</a>, as defined by <a href=
@@ -55,79 +57,48 @@ public interface BlankNode extends BlankNodeOrIRI {
 	/**
 	 * Return a <a href=
 	 * "http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier"
-	 * >label</a> for the blank node. This is not a serialization/syntax label.
-	 * It should be uniquely identifying within the local scope it is created in
-	 * but has no uniqueness guarantees other than that.
+	 * >identifier</a> for the blank node as an {@link UUID}. 
+	 * This is not a serialization/syntax label.
+	 * It should be uniquely identifying the blank node, but does not
+	 * come with any guarantees for persistence or resolution.
 	 * <p>
-	 * In particular, the existence of two objects of type {@link BlankNode}
-	 * with the same value returned from {@link #internalIdentifier()} are not
-	 * equivalent unless they are known to have been created in the same local
-	 * scope (see {@link #equals(Object)})
+	 * Two objects of the type <code>BlankNode</code> with the same
+	 * value returned from {@link #identifier()} are equivalent, 
+	 * and thus are in the same local scope.
+	 * (see {@link #equals(Object)}).
 	 * <p>
-	 * An example of a local scope may be an instance of a Java Virtual Machine
-	 * (JVM). In the context of a JVM instance, an implementor may support
-	 * insertion and removal of {@link Triple} objects containing Blank Nodes
-	 * without modifying the blank node labels.
+	 * On the other hand, two <code>BlankNode</code> objects
+	 * with different <code>identifier()</code> values are not 
+	 * necessarily different.
 	 * <p>
-	 * Another example of a local scope may be a <a
-	 * href="http://www.w3.org/TR/rdf11-concepts/#section-rdf-graph">Graph</a>
-	 * or <a
-	 * href="http://www.w3.org/TR/rdf11-concepts/#section-dataset">Dataset</a>
-	 * created from a single document. In this context, an implementor should
-	 * reasonably guarantee that the label returned by getLabel only maps to
-	 * equivalent blank nodes in the same Graph or Dataset, but they may not
-	 * guarantee that it is unique for the JVM instance. In this case, the
-	 * implementor may support a mechanism to provide a mapping for blank nodes
-	 * between Graph or Dataset instances to guarantee their uniqueness.
-	 * <p>
-	 * If implementors support <a
-	 * href="http://www.w3.org/TR/rdf11-concepts/#section-skolemization"
-	 * >Skolemisation</a>, they may map instances of {@link BlankNode} objects
-	 * to {@link IRI} objects to reduce scoping issues.
-	 * <p>
-	 * It is not a requirement for the internal identifier to be a part of the
+	 * It is not a requirement for the identifier to be a part of the
 	 * {@link #ntriplesString()}, except that two BlankNode instances with the
-	 * same internalIdentifier() and same local scope should have the same
+	 * same <code>identifier()</code>, and same local scope SHOULD have the same
 	 * {@link #ntriplesString()}.
 	 *
-	 * @return An internal, system identifier for the {@link BlankNode}.
+	 * @see #equals(Object)
+	 *
+	 * @return An unique identifier for the {@link BlankNode}.
 	 */
-	String internalIdentifier();
+	UUID identifier();
 
 	/**
-	 * Check it this BlankNode is equal to another BlankNode. <blockquote> <a
-	 * href
-	 * ="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">Blank
-	 * node identifiers</a> are local identifiers that are used in some concrete
-	 * RDF syntaxes or RDF store implementations. They are always locally scoped
-	 * to the file or RDF store, and are <em>not</em> persistent or portable
-	 * identifiers for blank nodes. Blank node identifiers are <em>not</em> part
-	 * of the RDF abstract syntax, but are entirely dependent on the concrete
-	 * syntax or implementation. The syntactic restrictions on blank node
-	 * identifiers, if any, therefore also depend on the concrete RDF syntax or
-	 * implementation. 
-	 * <p>Implementations that handle blank node identifiers in
-	 * concrete syntaxes need to be careful not to create the same blank node
-	 * from multiple occurrences of the same blank node identifier except in
-	 * situations where this is supported by the syntax. 
-	 * </blockquote>
+	 * Check it this BlankNode is equal to another BlankNode. 
 	 * <p>
-	 * Implementations MUST check the local scope, as two BlankNode in different
-	 * Graphs MUST differ. On the other hand, two BlankNodes found in triples of
-	 * the same Graph instance MUST equal if and only if they have the same
-	 * {@link #internalIdentifier()}.
-	 * </p>
+	 * Two BlankNodes MUST be equal if they have the same {@link #identifier()},
+	 * and MAY be equal if their {@link #identifier()} differ.
 	 * <p>
 	 * Implementations MUST also override {@link #hashCode()} so that two equal
-	 * Literals produce the same hash code.
+	 * <code>BlankNode</code> instances produce the same hash code.
 	 * </p>
 	 * 
+	 * @see #identifier()
 	 * @see Object#equals(Object)
+	 * @see #hashCode()
 	 * 
 	 * @param other
 	 *            Another object
-	 * @return true if other is a BlankNode, is in the same local scope and is
-	 *         equal to this BlankNode
+	 * @return true if other is a BlankNode and is equal to this BlankNode
 	 */
 	@Override
 	public boolean equals(Object other);

--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -71,10 +71,8 @@ public interface BlankNode extends BlankNodeOrIRI {
 	 * with different <code>identifier()</code> values are not 
 	 * necessarily different.
 	 * <p>
-	 * It is not a requirement for the identifier to be a part of the
-	 * {@link #ntriplesString()}, except that two BlankNode instances with the
-	 * same <code>identifier()</code>, and same local scope SHOULD have the same
-	 * {@link #ntriplesString()}.
+	 * It is not a requirement for this UUID <code>identifier</code> to form part of the
+	 * {@link #ntriplesString()}. 
 	 *
 	 * @see #equals(Object)
 	 *

--- a/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
+++ b/api/src/main/java/com/github/commonsrdf/api/BlankNode.java
@@ -81,14 +81,23 @@ public interface BlankNode extends BlankNodeOrIRI {
 	UUID identifier();
 
 	/**
-	 * Check it this BlankNode is equal to another BlankNode. 
+	 * Check it this BlankNode is equal to another BlankNode.
 	 * <p>
 	 * Two BlankNodes MUST be equal if they have the same {@link #identifier()},
 	 * and MAY be equal if their {@link #identifier()} differ.
 	 * <p>
 	 * Implementations MUST also override {@link #hashCode()} so that two equal
 	 * <code>BlankNode</code> instances produce the same hash code.
-	 * </p>
+	 * <p>
+	 * Note: 
+	 * <blockquote
+	 *   cite="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node">
+	 * Implementations that handle <a
+	 * href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node">blank node
+	 * identifiers</a> in concrete syntaxes need to be careful not to create the
+	 * same blank node from multiple occurrences of the same blank node
+	 * identifier except in situations where this is supported by the syntax.
+	 * </blockquote>
 	 * 
 	 * @see #identifier()
 	 * @see Object#equals(Object)

--- a/api/src/main/java/com/github/commonsrdf/api/RDFTermFactory.java
+++ b/api/src/main/java/com/github/commonsrdf/api/RDFTermFactory.java
@@ -66,7 +66,7 @@ public interface RDFTermFactory {
 	 * skolem IRI</a>.
 	 * <p> 
 	 * The identifier is <strong>not</strong> a serialization/syntax label, 
-	 * e.g. not of the type <del><code>_:b2</code></del>.
+	 * e.g. not <del><code>_:b2</code></del>.
 	 * <p>
 	 * The {@link BlankNode#identifier()} of the returned
 	 * blank node SHOULD be equal to the provided identifier.

--- a/api/src/main/java/com/github/commonsrdf/api/RDFTermFactory.java
+++ b/api/src/main/java/com/github/commonsrdf/api/RDFTermFactory.java
@@ -41,7 +41,7 @@ public interface RDFTermFactory {
 	 * <p>
 	 * Two BlankNodes created with this method MUST NOT be equal.
 	 * <p>
-	 * If supported, the {@link BlankNode#internalIdentifier()} of the returned
+	 * If supported, the {@link BlankNode#identifier()} of the returned
 	 * blank node MUST be an auto-generated value.
 	 * 
 	 * @return A new BlankNode
@@ -60,7 +60,7 @@ public interface RDFTermFactory {
 	 * equal if they are in the same local scope (e.g. in the same Graph). See
 	 * the equals contract for {@link BlankNode} for more information.
 	 * <p>
-	 * If supported, the {@link BlankNode#internalIdentifier()} of the returned
+	 * If supported, the {@link BlankNode#identifier()} of the returned
 	 * blank node MAY be equal to the provided identifier.
 	 * 
 	 * @param identifier

--- a/api/src/main/java/com/github/commonsrdf/api/RDFTermFactory.java
+++ b/api/src/main/java/com/github/commonsrdf/api/RDFTermFactory.java
@@ -55,10 +55,21 @@ public interface RDFTermFactory {
 	}
 
 	/**
-	 * Create a blank node for the given UUID identifier.
+	 * Create a blank node for the given identifier.
 	 * <p>
-	 * If supported, the {@link BlankNode#identifier()} of the returned
-	 * blank node MUST be equal to the provided identifier.
+	 * The identifier MUST be globally unique. It is RECOMMENDED 
+	 * for the identifier to be a UUID string, e.g. 
+	 * <code>9098f7bd-58fc-32d2-91a2-db6a19aaa46f</code>.
+	 * <p>
+	 * If the identifier is a IRI, it SHOULD be a  
+	 * <a href="http://www.w3.org/TR/rdf11-concepts/#section-skolemization">
+	 * skolem IRI</a>.
+	 * <p> 
+	 * The identifier is <strong>not</strong> a serialization/syntax label, 
+	 * e.g. not of the type <del><code>_:b2</code></del>.
+	 * <p>
+	 * The {@link BlankNode#identifier()} of the returned
+	 * blank node SHOULD be equal to the provided identifier.
 	 * <p>
 	 * Two BlankNodes created with the same identifier using this method 
 	 * MUST be equal.
@@ -68,15 +79,15 @@ public interface RDFTermFactory {
 	 * @see BlankNode#equals(Object)
 	 * 
 	 * @param identifier
-	 *            A UUID that uniquely identify the blank node
+	 *            A string that uniquely identify the blank node
 	 * @return A BlankNode for the given identifier
 	 * @throws UnsupportedOperationException
 	 *             If the operation is not supported.
 	 */
-	default BlankNode createBlankNode(UUID identifier)
+	default BlankNode createBlankNode(String identifier)
 			throws UnsupportedOperationException {
 		throw new UnsupportedOperationException(
-				"createBlankNode(UUID) not supported");
+				"createBlankNode(String) not supported");
 	}
 
 	/**

--- a/api/src/main/java/com/github/commonsrdf/api/RDFTermFactory.java
+++ b/api/src/main/java/com/github/commonsrdf/api/RDFTermFactory.java
@@ -14,6 +14,7 @@
 package com.github.commonsrdf.api;
 
 import java.util.Locale;
+import java.util.UUID;
 
 /**
  * Factory for creating RDFTerm and Graph instances.
@@ -42,7 +43,7 @@ public interface RDFTermFactory {
 	 * Two BlankNodes created with this method MUST NOT be equal.
 	 * <p>
 	 * If supported, the {@link BlankNode#identifier()} of the returned
-	 * blank node MUST be an auto-generated value.
+	 * blank node MUST be a freshly generated UUID.
 	 * 
 	 * @return A new BlankNode
 	 * @throws UnsupportedOperationException
@@ -54,30 +55,28 @@ public interface RDFTermFactory {
 	}
 
 	/**
-	 * Create a blank node for the given internal identifier.
-	 * <p>
-	 * Two BlankNodes created with the same identifier using this method MUST be
-	 * equal if they are in the same local scope (e.g. in the same Graph). See
-	 * the equals contract for {@link BlankNode} for more information.
+	 * Create a blank node for the given UUID identifier.
 	 * <p>
 	 * If supported, the {@link BlankNode#identifier()} of the returned
-	 * blank node MAY be equal to the provided identifier.
+	 * blank node MUST be equal to the provided identifier.
+	 * <p>
+	 * Two BlankNodes created with the same identifier using this method 
+	 * MUST be equal.
+	 * <p>
+	 * 
+	 * @see BlankNode#identifier()
+	 * @see BlankNode#equals(Object)
 	 * 
 	 * @param identifier
-	 *            A non-empty String that is unique to this blank node in this
-	 *            scope, and which may be used as the internal identifier for
-	 *            the blank node.
+	 *            A UUID that uniquely identify the blank node
 	 * @return A BlankNode for the given identifier
-	 * @throws IllegalArgumentException
-	 *             if the identifier is not acceptable, e.g. was empty or
-	 *             contained unsupported characters.
 	 * @throws UnsupportedOperationException
 	 *             If the operation is not supported.
 	 */
-	default BlankNode createBlankNode(String identifier)
-			throws IllegalArgumentException, UnsupportedOperationException {
+	default BlankNode createBlankNode(UUID identifier)
+			throws UnsupportedOperationException {
 		throw new UnsupportedOperationException(
-				"createBlankNode(String) not supported");
+				"createBlankNode(UUID) not supported");
 	}
 
 	/**

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractBlankNodeTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractBlankNodeTest.java
@@ -13,9 +13,8 @@
  */
 package com.github.commonsrdf.api;
 
-import static org.junit.Assert.*;
-
-import java.util.UUID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import org.junit.Test;
 
@@ -42,7 +41,7 @@ public abstract class AbstractBlankNodeTest {
 	 *            node that is returned.
 	 * @return A new blank node based on the
 	 */
-	protected abstract BlankNode getBlankNode(UUID identifier);
+	protected abstract BlankNode getBlankNode(String identifier);
 
 	/**
 	 * Test method for
@@ -57,15 +56,15 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public UUID identifier() {
+			public String identifier() {
 				return null;
 			}
 		};
 		BlankNode testAutomatic1 = getBlankNode();
 		BlankNode testAutomatic2 = getBlankNode();
 		
-		UUID uuid3 = UUID.fromString("b6415793-b706-4cbe-b406-14bad9c8e66f");
-		UUID uuid4 = UUID.fromString("36638869-2d18-4499-8be4-5b7434f9da45");		
+		String uuid3 = ("b6415793-b706-4cbe-b406-14bad9c8e66f");
+		String uuid4 = ("36638869-2d18-4499-8be4-5b7434f9da45");		
 		
 		BlankNode testManual3a = getBlankNode(uuid3);
 		BlankNode testManual3b = getBlankNode(uuid3);
@@ -111,14 +110,14 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public UUID identifier() {
+			public String identifier() {
 				return null;
 			}
 		};
 		BlankNode testAutomatic1 = getBlankNode();
 		BlankNode testAutomatic2 = getBlankNode();
-		UUID uuid3 = UUID.fromString("b6415793-b706-4cbe-b406-14bad9c8e66f");
-		UUID uuid4 = UUID.fromString("36638869-2d18-4499-8be4-5b7434f9da45");		
+		String uuid3 = "b6415793-b706-4cbe-b406-14bad9c8e66f";
+		String uuid4 = "36638869-2d18-4499-8be4-5b7434f9da45";		
 		BlankNode testManual3a = getBlankNode(uuid3);
 		BlankNode testManual3b = getBlankNode(uuid3);
 		BlankNode testManual4 = getBlankNode(uuid4);
@@ -151,14 +150,14 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public UUID identifier() {
+			public String identifier() {
 				return null;
 			}
 		};
 		BlankNode testAutomatic1 = getBlankNode();
 		BlankNode testAutomatic2 = getBlankNode();
-		UUID uuid3 = UUID.fromString("b6415793-b706-4cbe-b406-14bad9c8e66f");
-		UUID uuid4 = UUID.fromString("36638869-2d18-4499-8be4-5b7434f9da45");		
+		String uuid3 = "b6415793-b706-4cbe-b406-14bad9c8e66f";
+		String uuid4 = "36638869-2d18-4499-8be4-5b7434f9da45";		
 		BlankNode testManual3a = getBlankNode(uuid3);
 		BlankNode testManual3b = getBlankNode(uuid3);
 		BlankNode testManual4 = getBlankNode(uuid4);
@@ -192,14 +191,14 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public UUID identifier() {
+			public String identifier() {
 				return null;
 			}
 		};
 		BlankNode testAutomatic1 = getBlankNode();
 		BlankNode testAutomatic2 = getBlankNode();
-		UUID uuid3 = UUID.fromString("b6415793-b706-4cbe-b406-14bad9c8e66f");
-		UUID uuid4 = UUID.fromString("36638869-2d18-4499-8be4-5b7434f9da45");		
+		String uuid3 = "b6415793-b706-4cbe-b406-14bad9c8e66f";
+		String uuid4 = "36638869-2d18-4499-8be4-5b7434f9da45";		
 		BlankNode testManual3a = getBlankNode(uuid3);
 		BlankNode testManual3b = getBlankNode(uuid3);
 		BlankNode testManual4 = getBlankNode(uuid4);

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractBlankNodeTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractBlankNodeTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractBlankNodeTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.commonsrdf.api.BlankNode#internalIdentifier()}.
+	 * {@link com.github.commonsrdf.api.BlankNode#identifier()}.
 	 */
 	@Test
 	public final void testInternalIdentifier() {
@@ -55,7 +55,7 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public String internalIdentifier() {
+			public String identifier() {
 				return null;
 			}
 		};
@@ -66,30 +66,30 @@ public abstract class AbstractBlankNodeTest {
 		BlankNode testManual4 = getBlankNode("4");
 
 		// Test against our fake stub
-		assertNotEquals(testNull.internalIdentifier(),
-				testAutomatic1.internalIdentifier());
-		assertNotEquals(testAutomatic1.internalIdentifier(),
-				testNull.internalIdentifier());
-		assertNotEquals(testNull.internalIdentifier(),
-				testManual3a.internalIdentifier());
-		assertNotEquals(testManual3a.internalIdentifier(),
-				testNull.internalIdentifier());
+		assertNotEquals(testNull.identifier(),
+				testAutomatic1.identifier());
+		assertNotEquals(testAutomatic1.identifier(),
+				testNull.identifier());
+		assertNotEquals(testNull.identifier(),
+				testManual3a.identifier());
+		assertNotEquals(testManual3a.identifier(),
+				testNull.identifier());
 
 		// Test the two imported instances against each other
-		assertEquals(testAutomatic1.internalIdentifier(),
-				testAutomatic1.internalIdentifier());
-		assertEquals(testAutomatic2.internalIdentifier(),
-				testAutomatic2.internalIdentifier());
-		assertNotEquals(testAutomatic1.internalIdentifier(),
-				testAutomatic2.internalIdentifier());
-		assertNotEquals(testAutomatic2.internalIdentifier(),
-				testAutomatic1.internalIdentifier());
-		assertNotEquals(testAutomatic1.internalIdentifier(),
-				testManual3a.internalIdentifier());
-		assertEquals(testManual3b.internalIdentifier(),
-				testManual3a.internalIdentifier());
-		assertNotEquals(testManual3a.internalIdentifier(),
-				testManual4.internalIdentifier());
+		assertEquals(testAutomatic1.identifier(),
+				testAutomatic1.identifier());
+		assertEquals(testAutomatic2.identifier(),
+				testAutomatic2.identifier());
+		assertNotEquals(testAutomatic1.identifier(),
+				testAutomatic2.identifier());
+		assertNotEquals(testAutomatic2.identifier(),
+				testAutomatic1.identifier());
+		assertNotEquals(testAutomatic1.identifier(),
+				testManual3a.identifier());
+		assertEquals(testManual3b.identifier(),
+				testManual3a.identifier());
+		assertNotEquals(testManual3a.identifier(),
+				testManual4.identifier());
 	}
 
 	/**
@@ -105,7 +105,7 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public String internalIdentifier() {
+			public String identifier() {
 				return null;
 			}
 		};
@@ -143,7 +143,7 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public String internalIdentifier() {
+			public String identifier() {
 				return null;
 			}
 		};
@@ -182,7 +182,7 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public String internalIdentifier() {
+			public String identifier() {
 				return null;
 			}
 		};

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractBlankNodeTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractBlankNodeTest.java
@@ -15,6 +15,8 @@ package com.github.commonsrdf.api;
 
 import static org.junit.Assert.*;
 
+import java.util.UUID;
+
 import org.junit.Test;
 
 /**
@@ -40,7 +42,7 @@ public abstract class AbstractBlankNodeTest {
 	 *            node that is returned.
 	 * @return A new blank node based on the
 	 */
-	protected abstract BlankNode getBlankNode(String identifier);
+	protected abstract BlankNode getBlankNode(UUID identifier);
 
 	/**
 	 * Test method for
@@ -55,15 +57,19 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public String identifier() {
+			public UUID identifier() {
 				return null;
 			}
 		};
 		BlankNode testAutomatic1 = getBlankNode();
 		BlankNode testAutomatic2 = getBlankNode();
-		BlankNode testManual3a = getBlankNode("3");
-		BlankNode testManual3b = getBlankNode("3");
-		BlankNode testManual4 = getBlankNode("4");
+		
+		UUID uuid3 = UUID.fromString("b6415793-b706-4cbe-b406-14bad9c8e66f");
+		UUID uuid4 = UUID.fromString("36638869-2d18-4499-8be4-5b7434f9da45");		
+		
+		BlankNode testManual3a = getBlankNode(uuid3);
+		BlankNode testManual3b = getBlankNode(uuid3);
+		BlankNode testManual4 = getBlankNode(uuid4);
 
 		// Test against our fake stub
 		assertNotEquals(testNull.identifier(),
@@ -105,15 +111,17 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public String identifier() {
+			public UUID identifier() {
 				return null;
 			}
 		};
 		BlankNode testAutomatic1 = getBlankNode();
 		BlankNode testAutomatic2 = getBlankNode();
-		BlankNode testManual3a = getBlankNode("3");
-		BlankNode testManual3b = getBlankNode("3");
-		BlankNode testManual4 = getBlankNode("4");
+		UUID uuid3 = UUID.fromString("b6415793-b706-4cbe-b406-14bad9c8e66f");
+		UUID uuid4 = UUID.fromString("36638869-2d18-4499-8be4-5b7434f9da45");		
+		BlankNode testManual3a = getBlankNode(uuid3);
+		BlankNode testManual3b = getBlankNode(uuid3);
+		BlankNode testManual4 = getBlankNode(uuid4);
 
 		// Test against our fake stub
 		assertNotEquals(testNull, testAutomatic1);
@@ -143,15 +151,17 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public String identifier() {
+			public UUID identifier() {
 				return null;
 			}
 		};
 		BlankNode testAutomatic1 = getBlankNode();
 		BlankNode testAutomatic2 = getBlankNode();
-		BlankNode testManual3a = getBlankNode("3");
-		BlankNode testManual3b = getBlankNode("3");
-		BlankNode testManual4 = getBlankNode("4");
+		UUID uuid3 = UUID.fromString("b6415793-b706-4cbe-b406-14bad9c8e66f");
+		UUID uuid4 = UUID.fromString("36638869-2d18-4499-8be4-5b7434f9da45");		
+		BlankNode testManual3a = getBlankNode(uuid3);
+		BlankNode testManual3b = getBlankNode(uuid3);
+		BlankNode testManual4 = getBlankNode(uuid4);
 
 		// Test against our fake stub
 		assertNotEquals(testNull.hashCode(), testAutomatic1.hashCode());
@@ -182,15 +192,17 @@ public abstract class AbstractBlankNodeTest {
 			}
 
 			@Override
-			public String identifier() {
+			public UUID identifier() {
 				return null;
 			}
 		};
 		BlankNode testAutomatic1 = getBlankNode();
 		BlankNode testAutomatic2 = getBlankNode();
-		BlankNode testManual3a = getBlankNode("3");
-		BlankNode testManual3b = getBlankNode("3");
-		BlankNode testManual4 = getBlankNode("4");
+		UUID uuid3 = UUID.fromString("b6415793-b706-4cbe-b406-14bad9c8e66f");
+		UUID uuid4 = UUID.fromString("36638869-2d18-4499-8be4-5b7434f9da45");		
+		BlankNode testManual3a = getBlankNode(uuid3);
+		BlankNode testManual3b = getBlankNode(uuid3);
+		BlankNode testManual4 = getBlankNode(uuid4);
 
 		// Test against our fake stub
 		assertNotEquals(testNull.ntriplesString(),

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractGraphTest.java
@@ -66,8 +66,8 @@ public abstract class AbstractGraphTest {
 		knows = factory.createIRI("http://xmlns.com/foaf/0.1/knows");
 		member = factory.createIRI("http://xmlns.com/foaf/0.1/member");
 		try {
-			org1 = factory.createBlankNode("org1");
-			org2 = factory.createBlankNode("org2");
+			org1 = factory.createBlankNode();
+			org2 = factory.createBlankNode();
 		} catch (UnsupportedOperationException ex) {
 			// leave as null
 		}
@@ -119,7 +119,7 @@ public abstract class AbstractGraphTest {
 				.startsWith(
 						"<http://example.com/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" ."));
 		assertTrue(graph.toString().endsWith(
-				"_:org2 <http://xmlns.com/foaf/0.1/name> \"A company\" ."));
+				" <http://xmlns.com/foaf/0.1/name> \"A company\" ."));
 
 	}
 

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractRDFTermFactoryTest {
 		BlankNode bnode2 = factory.createBlankNode();
 		assertNotEquals(
 				"Second blank node has not got a unique internal identifier",
-				bnode.internalIdentifier(), bnode2.internalIdentifier());
+				bnode.identifier(), bnode2.identifier());
 	}
 
 	@Test
@@ -72,7 +72,7 @@ public abstract class AbstractRDFTermFactoryTest {
 			Assume.assumeNoException(ex);
 			return;
 		}
-		assertEquals("example1", bnode.internalIdentifier());
+		assertEquals("example1", bnode.identifier());
 		// .. but we can't assume the internal identifier leaks into
 		// ntriplesString
 		// assertEquals("_:example1", bnode.ntriplesString());
@@ -89,7 +89,7 @@ public abstract class AbstractRDFTermFactoryTest {
 			Assume.assumeNoException(ex);
 			return;
 		}
-		assertEquals(bnode1.internalIdentifier(), bnode2.internalIdentifier());
+		assertEquals(bnode1.identifier(), bnode2.identifier());
 		// We don't know what the ntriplesString is, but it MUST be the same
 		assertEquals(bnode1.ntriplesString(), bnode2.ntriplesString());
 		// and here it MUST differ

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 
+import java.util.UUID;
+
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,39 +54,30 @@ public abstract class AbstractRDFTermFactoryTest {
 				bnode.identifier(), bnode2.identifier());
 	}
 
-	@Test
-	public void createBlankNodeIdentifierEmpty() throws Exception {
-		try {
-			factory.createBlankNode("");
-		} catch (UnsupportedOperationException e) {
-			Assume.assumeNoException(e);
-		} catch (IllegalArgumentException e) {
-			// Expected exception
-		}
-	}
 
 	@Test
 	public void createBlankNodeIdentifier() throws Exception {
+		UUID uuid = UUID.fromString("d85f1b8e-4f87-4847-a58b-283e3834e5c8");
 		BlankNode bnode;
 		try {
-			bnode = factory.createBlankNode("example1");
+			bnode = factory.createBlankNode(uuid);
 		} catch (UnsupportedOperationException ex) {
 			Assume.assumeNoException(ex);
 			return;
 		}
-		assertEquals("example1", bnode.identifier());
-		// .. but we can't assume the internal identifier leaks into
-		// ntriplesString
-		// assertEquals("_:example1", bnode.ntriplesString());
+		assertEquals(uuid, bnode.identifier());
 	}
 
 	@Test
 	public void createBlankNodeIdentifierTwice() throws Exception {
+		UUID uuid = UUID.fromString("959c0aaa-fcee-49d4-b62b-a6c496e81398");
+		UUID uuid2 = UUID.fromString("44ca1bc5-1ec2-4d3d-ae96-5f667e874721");
+
 		BlankNode bnode1, bnode2, bnode3;
 		try {
-			bnode1 = factory.createBlankNode("example1");
-			bnode2 = factory.createBlankNode("example1");
-			bnode3 = factory.createBlankNode("differ");
+			bnode1 = factory.createBlankNode(uuid);
+			bnode2 = factory.createBlankNode(uuid);
+			bnode3 = factory.createBlankNode(uuid2);
 		} catch (UnsupportedOperationException ex) {
 			Assume.assumeNoException(ex);
 			return;
@@ -280,9 +273,9 @@ public abstract class AbstractRDFTermFactoryTest {
 		BlankNode object;
 		Triple triple;
 		try {
-			subject = factory.createBlankNode("b1");
+			subject = factory.createBlankNode();
 			predicate = factory.createIRI("http://example.com/pred");
-			object = factory.createBlankNode("b2");
+			object = factory.createBlankNode();
 			triple = factory.createTriple(subject, predicate, object);
 		} catch (UnsupportedOperationException ex) {
 			Assume.assumeNoException(ex);
@@ -303,7 +296,7 @@ public abstract class AbstractRDFTermFactoryTest {
 		IRI object;
 		Triple triple;
 		try {
-			subject = factory.createBlankNode("b1");
+			subject = factory.createBlankNode();
 			predicate = factory.createIRI("http://example.com/pred");
 			object = factory.createIRI("http://example.com/obj");
 			triple = factory.createTriple(subject, predicate, object);
@@ -347,28 +340,6 @@ public abstract class AbstractRDFTermFactoryTest {
 		factory = createFactory();
 	}
 
-	@Test
-	public void possiblyInvalidBlankNode() throws Exception {
-		BlankNode withColon;
-		try {
-			withColon = factory.createBlankNode("with:colon");
-		} catch (UnsupportedOperationException ex) {
-			Assume.assumeNoException("createBlankNode(String) not supported",
-					ex);
-			return;
-		} catch (IllegalArgumentException ex) {
-			// Good!
-			return;
-		}
-		// Factory allows :colon, which is OK as long as it's not causing an
-		// invalid ntriplesString
-		assertFalse(withColon.ntriplesString().contains("with:colon"));
-
-		// and creating it twice gets the same ntriplesString
-		assertEquals(withColon.ntriplesString(),
-				factory.createBlankNode("with:colon").ntriplesString());
-	}
-
 	@Test(expected = IllegalArgumentException.class)
 	public void invalidIRI() throws Exception {
 		try {
@@ -392,9 +363,9 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test(expected = Exception.class)
 	public void invalidTriplePredicate() {
-		BlankNode subject = factory.createBlankNode("b1");
-		BlankNode predicate = factory.createBlankNode("b2");
-		BlankNode object = factory.createBlankNode("b3");
+		BlankNode subject = factory.createBlankNode();
+		BlankNode predicate = factory.createBlankNode();
+		BlankNode object = factory.createBlankNode();
 		factory.createTriple(subject, (IRI) predicate, object);
 	}
 

--- a/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
+++ b/api/src/test/java/com/github/commonsrdf/api/AbstractRDFTermFactoryTest.java
@@ -18,8 +18,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 
-import java.util.UUID;
-
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +55,7 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createBlankNodeIdentifier() throws Exception {
-		UUID uuid = UUID.fromString("d85f1b8e-4f87-4847-a58b-283e3834e5c8");
+		String uuid = "d85f1b8e-4f87-4847-a58b-283e3834e5c8";
 		BlankNode bnode;
 		try {
 			bnode = factory.createBlankNode(uuid);
@@ -70,8 +68,8 @@ public abstract class AbstractRDFTermFactoryTest {
 
 	@Test
 	public void createBlankNodeIdentifierTwice() throws Exception {
-		UUID uuid = UUID.fromString("959c0aaa-fcee-49d4-b62b-a6c496e81398");
-		UUID uuid2 = UUID.fromString("44ca1bc5-1ec2-4d3d-ae96-5f667e874721");
+		String uuid = "959c0aaa-fcee-49d4-b62b-a6c496e81398";
+		String uuid2 = "44ca1bc5-1ec2-4d3d-ae96-5f667e874721";
 
 		BlankNode bnode1, bnode2, bnode3;
 		try {

--- a/simple/src/main/java/com/github/commonsrdf/simple/BlankNodeImpl.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/BlankNodeImpl.java
@@ -13,15 +13,10 @@
  */
 package com.github.commonsrdf.simple;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 
 import com.github.commonsrdf.api.BlankNode;
-import com.github.commonsrdf.api.Graph;
 
 /**
  * A simple implementation of BlankNode.
@@ -29,37 +24,24 @@ import com.github.commonsrdf.api.Graph;
  */
 class BlankNodeImpl implements BlankNode {
 
-	private static AtomicLong bnodeCounter = new AtomicLong();
-	private final String id;
-	private final Optional<Graph> localScope;
+	private final UUID id;
 
 	public BlankNodeImpl() {
-		this(Optional.empty(), "b:" + bnodeCounter.incrementAndGet());
+		this(UUID.randomUUID());
 	}
 
-	public BlankNodeImpl(Optional<Graph> localScope, String id) {
-		this.localScope = Objects.requireNonNull(localScope);
-		if (Objects.requireNonNull(id).isEmpty()) {
-			throw new IllegalArgumentException("Invalid blank node id: " + id);
-			// NOTE: It is valid for the id to not be a valid ntriples bnode id.
-			// See ntriplesString().
-		}
-		this.id = id;
+	public BlankNodeImpl(UUID id) {
+		this.id = Objects.requireNonNull(id);
 	}
 
 	@Override
-	public String identifier() {
+	public UUID identifier() {
 		return id;
 	}
 
 	@Override
 	public String ntriplesString() {
-		if (id.contains(":")) {
-			return "_:u"
-					+ UUID.nameUUIDFromBytes(id
-							.getBytes(StandardCharsets.UTF_8));
-		}
-		return "_:" + id;
+		return "_:" + identifier();
 	}
 
 	@Override
@@ -69,7 +51,7 @@ class BlankNodeImpl implements BlankNode {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(localScope, id);
+		return identifier().hashCode();
 	}
 
 	@Override
@@ -77,28 +59,11 @@ class BlankNodeImpl implements BlankNode {
 		if (this == obj) {
 			return true;
 		}
-		if (obj == null) {
+		if (!(obj instanceof BlankNode)) {
 			return false;
 		}
-		if (!(obj instanceof BlankNodeImpl)) {
-			return false;
-		}
-		BlankNodeImpl other = (BlankNodeImpl) obj;
-		if (id == null) {
-			if (other.id != null) {
-				return false;
-			}
-		} else if (!id.equals(other.id)) {
-			return false;
-		}
-		if (localScope == null) {
-			if (other.localScope != null) {
-				return false;
-			}
-		} else if (!localScope.equals(other.localScope)) {
-			return false;
-		}
-		return true;
+		BlankNode other = (BlankNode) obj;
+		return identifier().equals(other.identifier());
 	}
 
 }

--- a/simple/src/main/java/com/github/commonsrdf/simple/BlankNodeImpl.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/BlankNodeImpl.java
@@ -48,7 +48,7 @@ class BlankNodeImpl implements BlankNode {
 	}
 
 	@Override
-	public String internalIdentifier() {
+	public String identifier() {
 		return id;
 	}
 

--- a/simple/src/main/java/com/github/commonsrdf/simple/GraphImpl.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/GraphImpl.java
@@ -15,7 +15,6 @@ package com.github.commonsrdf.simple;
 
 import java.util.LinkedHashSet;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -49,7 +48,7 @@ class GraphImpl implements Graph {
 
 	@Override
 	public void add(Triple triple) {
-		triples.add(new TripleImpl(Optional.of(this), Objects
+		triples.add(new TripleImpl(Objects
 				.requireNonNull(triple)));
 	}
 

--- a/simple/src/main/java/com/github/commonsrdf/simple/SimpleRDFTermFactory.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/SimpleRDFTermFactory.java
@@ -13,7 +13,7 @@
  */
 package com.github.commonsrdf.simple;
 
-import java.util.Optional;
+import java.util.UUID;
 
 import com.github.commonsrdf.api.BlankNode;
 import com.github.commonsrdf.api.BlankNodeOrIRI;
@@ -40,8 +40,8 @@ public class SimpleRDFTermFactory implements RDFTermFactory {
 	}
 
 	@Override
-	public BlankNode createBlankNode(String identifier) {
-		return new BlankNodeImpl(Optional.empty(), identifier);
+	public BlankNode createBlankNode(UUID identifier) {
+		return new BlankNodeImpl(identifier);
 	}
 
 	@Override

--- a/simple/src/main/java/com/github/commonsrdf/simple/SimpleRDFTermFactory.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/SimpleRDFTermFactory.java
@@ -40,7 +40,7 @@ public class SimpleRDFTermFactory implements RDFTermFactory {
 	}
 
 	@Override
-	public BlankNode createBlankNode(UUID identifier) {
+	public BlankNode createBlankNode(String identifier) {
 		return new BlankNodeImpl(identifier);
 	}
 

--- a/simple/src/main/java/com/github/commonsrdf/simple/TripleImpl.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/TripleImpl.java
@@ -78,7 +78,7 @@ class TripleImpl implements Triple {
 		if (object instanceof BlankNode) {
 			BlankNode blankNode = (BlankNode) object;
 			return new BlankNodeImpl(Objects.requireNonNull(localScope),
-					blankNode.internalIdentifier());
+					blankNode.identifier());
 		} else if (object instanceof IRI && !(object instanceof IRIImpl)) {
 			IRI iri = (IRI) object;
 			return new IRIImpl(iri.getIRIString());

--- a/simple/src/main/java/com/github/commonsrdf/simple/TripleImpl.java
+++ b/simple/src/main/java/com/github/commonsrdf/simple/TripleImpl.java
@@ -14,11 +14,9 @@
 package com.github.commonsrdf.simple;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import com.github.commonsrdf.api.BlankNode;
 import com.github.commonsrdf.api.BlankNodeOrIRI;
-import com.github.commonsrdf.api.Graph;
 import com.github.commonsrdf.api.IRI;
 import com.github.commonsrdf.api.Literal;
 import com.github.commonsrdf.api.RDFTerm;
@@ -37,17 +35,16 @@ class TripleImpl implements Triple {
 	/**
 	 * Construct Triple from its constituent parts.
 	 * <p>
-	 * The parts may be copied to ensure they are in scope.
+	 * The parts may be copied if they are not from this implementation.
 	 * 
 	 * @param subject subject of triple
 	 * @param predicate predicate of triple
 	 * @param object object of triple
 	 */
 	public TripleImpl(BlankNodeOrIRI subject, IRI predicate, RDFTerm object) {
-		this.subject = (BlankNodeOrIRI) inScope(Optional.empty(),
-				Objects.requireNonNull(subject));
-		this.predicate = (IRI) inScope(null, Objects.requireNonNull(predicate));
-		this.object = inScope(Optional.empty(), Objects.requireNonNull(object));
+		this.subject = (BlankNodeOrIRI) cloneFromOtherImpl(Objects.requireNonNull(subject));
+		this.predicate = (IRI) cloneFromOtherImpl(Objects.requireNonNull(predicate));
+		this.object = cloneFromOtherImpl(Objects.requireNonNull(object));
 	}
 
 	/**
@@ -60,25 +57,24 @@ class TripleImpl implements Triple {
 	 * @param triple
 	 *            Triple to clone
 	 */
-	public TripleImpl(Optional<Graph> localScope, Triple triple) {
-		Objects.requireNonNull(localScope);
+	public TripleImpl(Triple triple) {
 		Objects.requireNonNull(triple);
 
-		this.subject = (BlankNodeOrIRI) inScope(localScope, triple.getSubject());
-		this.predicate = (IRI) inScope(localScope, triple.getPredicate());
-		this.object = inScope(localScope, triple.getObject());
+		this.subject = (BlankNodeOrIRI) cloneFromOtherImpl(triple.getSubject());
+		this.predicate = (IRI) cloneFromOtherImpl(triple.getPredicate());
+		this.object = cloneFromOtherImpl(triple.getObject());
 	}
 
-	private RDFTerm inScope(Optional<Graph> localScope, RDFTerm object) {
+	private RDFTerm cloneFromOtherImpl(RDFTerm object) {
 		if (!(object instanceof BlankNode) && !(object instanceof IRI)
 				& !(object instanceof Literal)) {
 			throw new IllegalArgumentException(
 					"RDFTerm must be BlankNode, IRI or Literal");
 		}
-		if (object instanceof BlankNode) {
+		if (object instanceof BlankNode && !(object instanceof BlankNodeImpl)) {
 			BlankNode blankNode = (BlankNode) object;
-			return new BlankNodeImpl(Objects.requireNonNull(localScope),
-					blankNode.identifier());
+			// Safe as the identifier() is unique across scopes
+			return new BlankNodeImpl(blankNode.identifier());
 		} else if (object instanceof IRI && !(object instanceof IRIImpl)) {
 			IRI iri = (IRI) object;
 			return new IRIImpl(iri.getIRIString());
@@ -89,10 +85,11 @@ class TripleImpl implements Triple {
 				return new LiteralImpl(literal.getLexicalForm(), literal
 						.getLanguageTag().get());
 			} else {
-				IRI dataType = (IRI) inScope(localScope, literal.getDatatype());
+				IRI dataType = (IRI) cloneFromOtherImpl(literal.getDatatype());
 				return new LiteralImpl(literal.getLexicalForm(), dataType);
 			}
 		} else {
+			// It must be one of ours.. safe to keep in multiple Triples
 			return object;
 		}
 	}

--- a/simple/src/test/java/com/github/commonsrdf/simple/BlankNodeImplTest.java
+++ b/simple/src/test/java/com/github/commonsrdf/simple/BlankNodeImplTest.java
@@ -31,7 +31,7 @@ public class BlankNodeImplTest extends AbstractBlankNodeTest {
 	}
 
 	@Override
-	protected BlankNode getBlankNode(UUID identifier) {
+	protected BlankNode getBlankNode(String identifier) {
 		return new BlankNodeImpl(identifier);
 	}
 

--- a/simple/src/test/java/com/github/commonsrdf/simple/BlankNodeImplTest.java
+++ b/simple/src/test/java/com/github/commonsrdf/simple/BlankNodeImplTest.java
@@ -13,7 +13,7 @@
  */
 package com.github.commonsrdf.simple;
 
-import java.util.Optional;
+import java.util.UUID;
 
 import com.github.commonsrdf.api.AbstractBlankNodeTest;
 import com.github.commonsrdf.api.BlankNode;
@@ -31,8 +31,8 @@ public class BlankNodeImplTest extends AbstractBlankNodeTest {
 	}
 
 	@Override
-	protected BlankNode getBlankNode(String identifier) {
-		return new BlankNodeImpl(Optional.empty(), identifier);
+	protected BlankNode getBlankNode(UUID identifier) {
+		return new BlankNodeImpl(identifier);
 	}
 
 }

--- a/simple/src/test/java/com/github/commonsrdf/simple/TestWritingGraph.java
+++ b/simple/src/test/java/com/github/commonsrdf/simple/TestWritingGraph.java
@@ -16,8 +16,6 @@ package com.github.commonsrdf.simple;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.junit.BeforeClass;
@@ -39,7 +37,7 @@ public class TestWritingGraph {
 
 	private static GraphImpl graph;
 
-	private static UUID subj = UUID.fromString("07d6fcb3-cac2-418b-84dd-c437e83dda5a");
+	private static String subj = "07d6fcb3-cac2-418b-84dd-c437e83dda5a";
 	
 	@BeforeClass
 	public static void createGraph() throws Exception {

--- a/simple/src/test/java/com/github/commonsrdf/simple/TestWritingGraph.java
+++ b/simple/src/test/java/com/github/commonsrdf/simple/TestWritingGraph.java
@@ -17,6 +17,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.junit.BeforeClass;
@@ -38,10 +39,12 @@ public class TestWritingGraph {
 
 	private static GraphImpl graph;
 
+	private static UUID subj = UUID.fromString("07d6fcb3-cac2-418b-84dd-c437e83dda5a");
+	
 	@BeforeClass
 	public static void createGraph() throws Exception {
 		graph = new GraphImpl();
-		BlankNode subject = new BlankNodeImpl(Optional.of(graph), "subj");
+		BlankNode subject = new BlankNodeImpl(subj);
 		IRI predicate = new IRIImpl("pred");
 		for (int i = 0; i < TRIPLES; i++) {
 			graph.add(subject, predicate, new LiteralImpl("Example " + i, "en"));
@@ -55,7 +58,7 @@ public class TestWritingGraph {
 	
 	@Test
 	public void countQuery() {
-		BlankNode subject = new BlankNodeImpl(Optional.of(graph), "subj");
+		BlankNode subject = new BlankNodeImpl(subj);
 		IRI predicate = new IRIImpl("pred");
 		long count = graph.getTriples(subject, predicate, null).unordered()
 				.parallel().count();
@@ -85,7 +88,7 @@ public class TestWritingGraph {
 			graphFile.toFile().deleteOnExit();
 		}
 
-		BlankNode subject = new BlankNodeImpl(Optional.of(graph), "subj");
+		BlankNode subject = new BlankNodeImpl(subj);
 		IRI predicate = new IRIImpl("pred");
 		Stream<CharSequence> stream = graph
 				.getTriples(subject, predicate, null).map(Object::toString);


### PR DESCRIPTION
A variant proposal of #63 

I putting this patch as a proposal for discussion, not giving my +1 yet.

*tl;dr: [BlankNode.identifier()](http://stain.github.io/commons-rdf/blanknode-identifier-only/com/github/commonsrdf/api/BlankNode.html#identifier--) returns a "globally unique identifier" - recommends UUID or Skolem IRI. Used for equality checks.*

Added:
>  The identifier MUST be globally unique. It is RECOMMENDED for the identifier to be a UUID string. If the identifier is a IRI, it is SHOULD be a skolem IRI.
> 
> It is NOT RECOMMENDED for this identifier to form part of the RDFTerm.ntriplesString().


Javadoc: http://stain.github.io/commons-rdf/blanknode-identifier-only/

Same discussion as in #63 applies, except:

* Implementations are more at freedom for what kind of identifier scheme they use
  * BUT: Must make those globally unique. `"jena:graph5:b4"` won't do. :)
* Users of the API might be more likely to mess up by sending in `b1` as the string to the [RDFTermFactory.createBlankNode(string)](http://stain.github.io/commons-rdf/blanknode-identifier-only/com/github/commonsrdf/api/RDFTermFactory.html#createBlankNode-java.lang.String-). Javadoc warning added.
