### PR TITLE
correct path to interface diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library is still work in progress.
 
 A draft diagram of the interfaces which may be included in Commons RDF are:
 
-![commons-rdf class diagram](commons-rdf-api/src/main/resources/commons-rdf-class-diagram.png "commons-rdf class diagram")
+![commons-rdf class diagram](api/src/main/resources/commons-rdf-class-diagram.png "commons-rdf class diagram")
 
 ## Building
 


### PR DESCRIPTION
The path to the interface diagram was using the wrong directory. It was looking in `commons-rdf-api` but seems to be now `api`.